### PR TITLE
Fix PCI ID validation

### DIFF
--- a/src/proxmox-configurator.sh
+++ b/src/proxmox-configurator.sh
@@ -401,7 +401,7 @@ read_gpu_id() {
         3>&1 1>&2 2>&3) || return 1
 
     # Validate PCI syntax: domain:bus.device.function
-    if ! [[ "$GPU_ID" =~ ^[0-9A-Fa-f]{4}:[0-9A-Fa-f]{2}\.[0-9A-Fa-f]$ ]]; then
+    if ! [[ "$GPU_ID" =~ ^[0-9A-Fa-f]{4}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}\.[0-9A-Fa-f]$ ]]; then
         whiptail --title "Error" --msgbox "Invalid PCI ID format: $GPU_ID" 8 60
         return 1
     fi


### PR DESCRIPTION
The instructions say the ID should be of format `0000:xx:xx.x` but the code validates `xxxx:xx.x`.