### PR TITLE
Experimental: template system hardening

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -9,101 +9,100 @@ permissions:
   contents: read
 
 env:
-  USERNAME:    "PECU Releases"
-  AVATAR_URL:  "https://raw.githubusercontent.com/Danilop95/Proxmox-Enhanced-Configuration-Utility/main/doc/img/logo.png"
-  COLOR_STABLE:    3066993      # verde
-  COLOR_BETA:      16776960     # amarillo
-  COLOR_PREVIEW:   16098851     # naranja
-  COLOR_LEGACY:     9807270     # azul-gris
-  COLOR_DEPRECATED: 15158332    # rojo
-  COLOR_DEFAULT:    5793266     # cyan
+  USERNAME: "PECU Releases"
+  AVATAR_URL: "https://raw.githubusercontent.com/Danilop95/Proxmox-Enhanced-Configuration-Utility/main/doc/img/Logo-PECU.png"
+  COLOR_STABLE: 3066993
+  COLOR_BETA: 16776960
+  COLOR_PREVIEW: 16098851
+  COLOR_LEGACY: 9807270
+  COLOR_DEPRECATED: 15158332
+  COLOR_DEFAULT: 5793266
 
 jobs:
   discord:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Parse release body
-      id: meta
-      shell: bash
-      run: |
-        TAG="${{ github.event.release.tag_name }}"
-        TITLE="${{ github.event.release.name || TAG }}"
-        URL='${{ github.event.release.html_url }}'
-        BODY='${{ github.event.release.body }}'
+      - name: Parse release body
+        id: meta
+        shell: bash
+        run: |
+          TAG="$(jq -r '.release.tag_name // ""' "$GITHUB_EVENT_PATH")"
+          TITLE="$(jq -r '.release.name // .release.tag_name // ""' "$GITHUB_EVENT_PATH")"
+          URL="$(jq -r '.release.html_url // ""' "$GITHUB_EVENT_PATH")"
+          BODY="$(jq -r '.release.body // ""' "$GITHUB_EVENT_PATH")"
 
-        CHANNEL=$(printf "%s" "$BODY" | grep -oP '(?<=PECU-Channel:\s).*' | tr -d '\r')
-        TITLE_OVR=$(printf "%s" "$BODY" | grep -oP '(?<=PECU-Title:\s).*'   | tr -d '\r')
-        DESC_OVR=$( printf "%s" "$BODY" | grep -oP '(?<=PECU-Desc:\s).*'    | tr -d '\r')
+          CHANNEL=$(printf "%s" "$BODY" | grep -oP '(?<=PECU-Channel:\s).*' | tr -d '\r')
+          TITLE_OVR=$(printf "%s" "$BODY" | grep -oP '(?<=PECU-Title:\s).*' | tr -d '\r')
+          DESC_OVR=$(printf "%s" "$BODY" | grep -oP '(?<=PECU-Desc:\s).*' | tr -d '\r')
 
-        [[ -n "$TITLE_OVR" ]] && TITLE="$TITLE_OVR"
+          [[ -n "$TITLE_OVR" ]] && TITLE="$TITLE_OVR"
 
-        DESC=$(printf "%s" "$BODY" | sed -n '/^### What/,$p' | head -c 3500)
-        [[ -n "$DESC_OVR" ]] && DESC="$DESC_OVR"
-        DESC=$(printf "%s" "$DESC" | jq -Rs .)   # JSON-escape
+          DESC=$(printf "%s" "$BODY" | sed -n '/^### What/,$p' | head -c 3500)
+          [[ -n "$DESC_OVR" ]] && DESC="$DESC_OVR"
+          DESC=$(printf "%s" "$DESC" | jq -Rs .)
 
-        case "${CHANNEL,,}" in
-          stable)        COLOR=$COLOR_STABLE  ;;
-          beta)          COLOR=$COLOR_BETA    ;;
-          preview|exp*)  COLOR=$COLOR_PREVIEW ;;
-          legacy)        COLOR=$COLOR_LEGACY  ;;
-          deprecated)    COLOR=$COLOR_DEPRECATED ;;
-          *)             COLOR=$COLOR_DEFAULT ;;
-        esac
+          case "${CHANNEL,,}" in
+            stable) COLOR=$COLOR_STABLE ;;
+            beta) COLOR=$COLOR_BETA ;;
+            preview|exp*) COLOR=$COLOR_PREVIEW ;;
+            legacy) COLOR=$COLOR_LEGACY ;;
+            deprecated) COLOR=$COLOR_DEPRECATED ;;
+            *) COLOR=$COLOR_DEFAULT ;;
+          esac
 
-        # decide webhook (stable/legacy público, resto patron)
-        case "${CHANNEL,,}" in
-          stable|legacy)         HOOK="$WEBHOOK_PUBLIC"  ;;
-          beta|preview|exp*|deprecated)  HOOK="$WEBHOOK_PATRON" ;;
-          *)                     HOOK="$WEBHOOK_PUBLIC"  ;;
-        esac
+          case "${CHANNEL,,}" in
+            stable|legacy) HOOK="$WEBHOOK_PUBLIC" ;;
+            beta|preview|exp*|deprecated) HOOK="$WEBHOOK_PATRON" ;;
+            *) HOOK="$WEBHOOK_PUBLIC" ;;
+          esac
 
-        echo "title=$TITLE"   >> $GITHUB_OUTPUT
-        echo "url=$URL"       >> $GITHUB_OUTPUT
-        echo "desc=$DESC"     >> $GITHUB_OUTPUT
-        echo "color=$COLOR"   >> $GITHUB_OUTPUT
-        echo "hook=$HOOK"     >> $GITHUB_OUTPUT
-        echo "tag=$TAG"       >> $GITHUB_OUTPUT
-        echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "desc=$DESC" >> "$GITHUB_OUTPUT"
+          echo "color=$COLOR" >> "$GITHUB_OUTPUT"
+          echo "hook=$HOOK" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
 
-    - name: Build payload.json
-      run: |
-        cat > payload.json <<EOF
-        {
-          "username": "${USERNAME}",
-          "avatar_url": "${AVATAR_URL}",
-          "embeds": [{
-            "title": "${{ steps.meta.outputs.title }}",
-            "url":   "${{ steps.meta.outputs.url }}",
-            "description": ${{ steps.meta.outputs.desc }},
-            "color": ${{ steps.meta.outputs.color }},
-            "fields": [
-              {
-                "name": "Quick Install",
-                "value": "```bash\nbash <(curl -sL https://raw.githubusercontent.com/${{ github.repository }}/${{ steps.meta.outputs.tag }}/proxmox-configurator.sh)\n```"
-              },
-              {
-                "name": "Release page",
-                "value": "[View on GitHub](${{ steps.meta.outputs.url }})"
-              }
-            ],
-            "footer": { "text": "${{ github.repository }} • ${{ steps.meta.outputs.tag }}" },
-            "timestamp": "${{ github.event.release.published_at }}"
-          }]
-        }
-        EOF
+      - name: Build payload.json
+        run: |
+          cat > payload.json <<EOF
+          {
+            "username": "${USERNAME}",
+            "avatar_url": "${AVATAR_URL}",
+            "embeds": [{
+              "title": "${{ steps.meta.outputs.title }}",
+              "url": "${{ steps.meta.outputs.url }}",
+              "description": ${{ steps.meta.outputs.desc }},
+              "color": ${{ steps.meta.outputs.color }},
+              "fields": [
+                {
+                  "name": "Quick Install",
+                  "value": "```bash\nbash <(curl -sL https://raw.githubusercontent.com/${{ github.repository }}/${{ steps.meta.outputs.tag }}/src/proxmox-configurator.sh)\n```"
+                },
+                {
+                  "name": "Release page",
+                  "value": "[View on GitHub](${{ steps.meta.outputs.url }})"
+                }
+              ],
+              "footer": { "text": "${{ github.repository }} • ${{ steps.meta.outputs.tag }}" },
+              "timestamp": "${{ github.event.release.published_at }}"
+            }]
+          }
+          EOF
 
-    - name: Post to Discord
-      run: |
-        curl -sS -H "Content-Type: application/json" \
-             --data @payload.json \
-             --fail --max-time 15 \
-             "${{ steps.meta.outputs.hook }}" \
-          | sed -e 's/^/Discord → /'
-      env:
-        WEBHOOK_PUBLIC:  ${{ secrets.WEBHOOK_PUBLIC }}
-        WEBHOOK_PATRON:  ${{ secrets.WEBHOOK_PATRON }}
+      - name: Post to Discord
+        run: |
+          curl -sS -H "Content-Type: application/json" \
+               --data @payload.json \
+               --fail --max-time 15 \
+               "${{ steps.meta.outputs.hook }}" \
+            | sed -e 's/^/Discord -> /'
+        env:
+          WEBHOOK_PUBLIC: ${{ secrets.WEBHOOK_PUBLIC }}
+          WEBHOOK_PATRON: ${{ secrets.WEBHOOK_PATRON }}
 
-    - name: Flag failure
-      if: failure()
-      run: echo "::error ::Discord webhook returned an error (check URL / permissions)"
+      - name: Flag failure
+        if: failure()
+        run: echo "::error ::Discord webhook returned an error (check URL / permissions)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,17 @@ on:
     branches:
       - main
     paths:
-      - src/proxmox-configurator.sh
+      - "src/**"
+      - "scripts/**"
+      - "templates/**"
+      - "README.md"
+      - "SECURITY.md"
+      - ".github/workflows/release.yml"
   workflow_dispatch:
 
 jobs:
   release:
-    name: Crear GitHub Release
+    name: Build and publish release bundle
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -19,79 +24,77 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Instalar dependencias
+      - name: Compute version
+        run: |
+          VERSION="$(date +'%Y.%m.%d-exp1')"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Install validation tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y dpkg-dev
+          sudo apt-get install -y shellcheck yamllint python3-jsonschema python3-yaml
 
-      - name: Obtener número de versión
-        id: version
+      - name: Validate release contents
+        env:
+          CI: "true"
         run: |
-          VERSION=$(date +'%Y.%m.%d')
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "VERSION=$VERSION"  # Debugging
+          chmod +x scripts/validate_repo.sh src/tools/templatectl.sh src/tools/renderers/qm.sh
+          scripts/validate_repo.sh
 
-      - name: Empaquetar script en tar.gz
+      - name: Build release bundle
         run: |
-          mkdir PECU-${{ env.VERSION }}
-          cp src/proxmox-configurator.sh PECU-${{ env.VERSION }}/
-          tar -czvf PECU-${{ env.VERSION }}.tar.gz PECU-${{ env.VERSION }}
+          package="PECU-${VERSION}"
+          mkdir "$package"
+          cp -a LICENSE README.md SECURITY.md src scripts templates "$package/"
+          find "$package" -type f -name '*.sh' -exec chmod +x {} +
+          tar -czf "${package}.tar.gz" "$package"
+          sha256sum "${package}.tar.gz" > SHA256SUMS
 
-      - name: Crear o actualizar GitHub Release
+      - name: Create or update GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ env.VERSION }}
-          name: "Release v${{ env.VERSION }}"
+          name: "PECU v${{ env.VERSION }}"
           update: true
           body: |
             <!--
-            PECU-Channel: Stable
-            PECU-Title:   EDIT TITLE HERE
-            PECU-Desc:    EDIT SHORT DESCRIPTION HERE
+            PECU-Channel: Experimental
+            PECU-Title: Template System Hardening and Release Safety Review
+            PECU-Desc: Safer VM template rendering, stronger validation, CI checks, and release/security documentation cleanup.
             -->
 
-            ### What's New in This Update
+            ### Contents
 
-            This update brings several improvements and bug fixes to enhance the performance and reliability of the Proxmox Enhanced Configuration Utility (PECU). Detailed changes include performance optimizations and improved error handling for a smoother experience.
+            This release publishes the full PECU project bundle:
 
-            ### How to Update
+            - `src/proxmox-configurator.sh`
+            - `scripts/pecu_release_selector.sh`
+            - `src/tools/templatectl.sh`
+            - `src/tools/renderers/qm.sh`
+            - `templates/`
+            - `scripts/validate_repo.sh`
+            - `README.md`, `SECURITY.md`, and `LICENSE`
 
-            You can update your PECU installation using the source code provided in this release. There are two ways to run this version:
+            ### Install
 
-            **Direct Execution (Latest Version):**  
-            Run the script directly from GitHub with this command:
             ```bash
-            bash <(curl -sL https://raw.githubusercontent.com/Danilop95/Proxmox-Enhanced-Configuration-Utility/v${{ env.VERSION }}/proxmox-configurator.sh)
+            VERSION="v${{ env.VERSION }}"
+            wget "https://github.com/${{ github.repository }}/releases/download/${VERSION}/PECU-${VERSION#v}.tar.gz"
+            wget "https://github.com/${{ github.repository }}/releases/download/${VERSION}/SHA256SUMS"
+            sha256sum -c SHA256SUMS
+            tar -xzf "PECU-${VERSION#v}.tar.gz"
+            cd "PECU-${VERSION#v}"
+            sudo ./src/proxmox-configurator.sh
             ```
-            This command fetches and executes the specific version (v${{ env.VERSION }}) of the script.
 
-            **Local Installation:**  
-            Alternatively, you can automate the entire process by executing the following command:
+            ### Template Validation
+
             ```bash
-            wget https://github.com/Danilop95/Proxmox-Enhanced-Configuration-Utility/releases/download/v${{ env.VERSION }}/PECU-${{ env.VERSION }}.tar.gz && \
-            tar -xzvf PECU-${{ env.VERSION }}.tar.gz && \
-            cd PECU-${{ env.VERSION }} && \
-            chmod +x proxmox-configurator.sh && \
-            sudo ./proxmox-configurator.sh
+            ./scripts/validate_repo.sh
+            ./src/tools/templatectl.sh apply templates/windows/windows-gaming.yaml --vmid 200 --storage-pool local-lvm --dry-run
             ```
-            This single command will:
-            1. Download the source code archive.
-            2. Extract the archive.
-            3. Change to the extracted directory.
-            4. Set executable permissions.
-            5. Execute the script.
-
-            ### Important Note
-
-            This release is a test release — it's the first time we're implementing automated releases. We apologize for any inconvenience caused by this initial notification. We are working to improve the release process for future versions.
-
-            ### Support the Project
-
-            If you enjoy using PECU and would like to see it continue to improve, consider making a donation. Your support helps maintain and expand this project. Thank you!
-
-            Best regards,  
-            Danilop95
-          draft: false
-          prerelease: false
+          draft: true
+          prerelease: true
           files: |
             PECU-${{ env.VERSION }}.tar.gz
+            SHA256SUMS

--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -1,68 +1,43 @@
-name: Templates CI
+name: PECU CI
 
 on:
   pull_request:
     paths:
-      - 'templates/**'
-      - 'src/tools/templatectl.sh'
-      - 'src/tools/renderers/**'
+      - "src/**"
+      - "scripts/**"
+      - "templates/**"
+      - ".github/workflows/**"
+      - ".yamllint.yaml"
+      - "README.md"
+      - "SECURITY.md"
   push:
-    branches: [ main ]
+    branches:
+      - main
     paths:
-      - 'templates/**'
-      - 'src/tools/templatectl.sh'
-      - 'src/tools/renderers/**'
+      - "src/**"
+      - "scripts/**"
+      - "templates/**"
+      - ".github/workflows/**"
+      - ".yamllint.yaml"
+      - "README.md"
+      - "SECURITY.md"
 
 jobs:
-  lint-validate:
+  validate:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
 
-      - name: Install tools
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install validation tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y jq curl python3 python3-pip shellcheck
-          pip3 install jsonschema pyyaml
-          # yq v4 está en GitHub releases; para CI usamos binario estático
-          YQ_VERSION="v4.44.3"
-          wget -q https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -O yq
-          chmod +x yq
-          sudo mv yq /usr/local/bin/yq
-          yq --version
+          sudo apt-get install -y shellcheck yamllint python3-jsonschema python3-yaml
 
-      - name: Yamllint
-        uses: ibiqlik/action-yamllint@v3
-        with:
-          strict: true
-          file_or_dir: templates/
-
-      - name: JSON Schema validate
+      - name: Run local validation
+        env:
+          CI: "true"
         run: |
-          python3 - <<'PY'
-          import sys, json, yaml, glob
-          from jsonschema import Draft202012Validator as V
-          schema = json.load(open('templates/schemas/template.schema.json'))
-          validator = V(schema)
-          ok = True
-          for f in glob.glob('templates/**/*.yaml', recursive=True):
-              try:
-                  data = yaml.safe_load(open(f))
-                  validator.validate(data)
-                  print('OK', f)
-              except Exception as e:
-                  ok = False
-                  print('FAIL', f, '->', e, file=sys.stderr)
-          sys.exit(0 if ok else 1)
-          PY
-
-      - name: Shellcheck
-        run: |
-          shellcheck -x src/tools/templatectl.sh src/tools/renderers/qm.sh
-
-      - name: Dry-run render all templates
-        run: |
-          chmod +x src/tools/templatectl.sh src/tools/renderers/qm.sh
-          find templates -name '*.yaml' -print0 | while IFS= read -r -d '' f; do
-            ./src/tools/templatectl.sh render "$f" --vmid 999 --storage-pool local-lvm --dry-run >/dev/null
-          done
+          chmod +x scripts/validate_repo.sh src/tools/templatectl.sh src/tools/renderers/qm.sh
+          scripts/validate_repo.sh

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 !LICENSE
 !README.md
 !SECURITY.md
+!RELEASE_NOTES_EXPERIMENTAL.md
 !.gitignore
 
 # Include configuration files

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,5 +1,6 @@
 extends: default
 rules:
+  document-start: disable
   line-length: disable
   truthy:
     allowed-values: ['true', 'false']

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Primary use cases:
 Notes:
 - ARM / Raspberry Pi builds of Proxmox are not supported at this time.
 - This project modifies system configuration (boot params, initramfs, modprobe). Review changes and ensure you have console access before applying.
+- The declarative template tooling needs `python3`, `PyYAML`, and `jsonschema` for local validation. A real Proxmox host is required only for non-dry-run `apply`.
 
 ---
 
@@ -124,6 +125,8 @@ All releases ship a `.tar.gz` bundle.
 ```bash
 VERSION="v2026.01.05"  # choose a tag from the Releases page
 wget "https://github.com/Danilop95/Proxmox-Enhanced-Configuration-Utility/releases/download/${VERSION}/PECU-${VERSION#v}.tar.gz"
+wget "https://github.com/Danilop95/Proxmox-Enhanced-Configuration-Utility/releases/download/${VERSION}/SHA256SUMS"
+sha256sum -c SHA256SUMS
 tar -xzf "PECU-${VERSION#v}.tar.gz"
 cd "PECU-${VERSION#v}"
 
@@ -147,6 +150,8 @@ fi
 
 `pecu_release_selector.sh` is an interactive menu that queries GitHub releases/tags and groups them by `PECU-Channel` metadata (Stable, Beta, Preview, Experimental, Nightly). This is intended to keep the list readable and to reduce accidental use of non-stable builds.
 
+Telemetry in the release selector is optional. In interactive mode it is disabled unless you explicitly opt in; it can also be forced off with `PECU_TELEMETRY=off`. Use `--json-preview` to inspect the telemetry payload without sending it.
+
 The legacy selector script (if present) is kept only for compatibility and may be removed in a future release.
 
 ---
@@ -159,20 +164,26 @@ Highlights:
 
 * Declarative YAML templates for common configurations
 * JSON Schema validation
-* CLI management (`templatectl.sh`) with `--dry-run` rendering
+* CLI management (`templatectl.sh`) with render and `apply --dry-run`
+* Safe apply path: commands are executed as argument arrays, not through `eval`
 * Storage pool flexibility (`local-lvm`, `local`, auto-detection)
+* Explicit policy gates for machine pinning and unsafe raw QEMU `args`
 
 Quick usage:
 
 ```bash
 # List available templates
-src/tools/templatectl.sh list --channel Stable
+src/tools/templatectl.sh list --channel Experimental
 
 # Validate all templates
 src/tools/templatectl.sh validate templates/
 
 # Preview commands (safe, no execution)
 src/tools/templatectl.sh render templates/windows/windows-gaming.yaml \
+  --vmid 200 --storage-pool local-lvm
+
+# Preview apply plan (safe, no execution, no Proxmox required)
+src/tools/templatectl.sh apply templates/windows/windows-gaming.yaml \
   --vmid 200 --storage-pool local-lvm --dry-run
 
 # Apply template (creates VM)
@@ -192,7 +203,7 @@ Before reporting a new issue, review the following known topics:
 * APU/iGPU platforms (e.g., AMD Ryzen Phoenix): VFIO binding must be surgical; incorrect binding can include unintended PCI IDs. See #33.
 * Offline/local install path differences: bundle layout can vary between releases; follow the robust offline steps above. See #31.
 * AMD 5700 XT vendor reset: vendor-reset effectiveness depends on model/kernel; tracked as FYI. See #29.
-* Template behavior reports: tracked in #25.
+* Template behavior reports: tracked in #25. Templates are schema-validated and dry-run tested in CI, but non-dry-run `qm apply` still needs validation on real Proxmox storage/network combinations.
 
 Issue tracker: [https://github.com/Danilop95/Proxmox-Enhanced-Configuration-Utility/issues](https://github.com/Danilop95/Proxmox-Enhanced-Configuration-Utility/issues)
 
@@ -252,7 +263,3 @@ If PECU is useful in your workflows and you want to support continued developmen
 ## License
 
 See [LICENSE](LICENSE).
-
-Important: ensure the README license statement matches the repository `LICENSE` file to avoid confusion (e.g., MIT vs GPL-3.0).
-
-```

--- a/RELEASE_NOTES_EXPERIMENTAL.md
+++ b/RELEASE_NOTES_EXPERIMENTAL.md
@@ -1,0 +1,124 @@
+<!--
+PECU-Channel: Experimental
+PECU-Title: Template System Hardening and Release Safety Review
+PECU-Desc: Safer VM template rendering, stronger validation, CI checks, and release/security documentation cleanup.
+-->
+
+# PECU Experimental Release - Template System Hardening
+
+## Why this release exists
+
+This release reduces risk in the PECU template system and aligns release
+packaging, validation, and security documentation with the current project
+state. It is not a Stable release because the renderer, template validation,
+release workflow, and safety checks changed in structural ways.
+
+## Main changes
+
+- Hardened VM template rendering.
+- Removed the unsafe eval-based template apply flow.
+- Fixed TPM generation from `spec.storage.tpm`.
+- Fixed boot disk generation to target `scsi0` instead of the bus name `scsi`.
+- Corrected Proxmox network syntax for `qm`.
+- Added explicit Q35 machine handling for the Windows 11 template.
+- Added stricter JSON Schema validation for template input.
+- Added a local repository validation script.
+- Added CI coverage for template validation and dry-run rendering.
+- Cleaned release packaging so the tarball contains the runnable project tree.
+- Cleaned `SECURITY.md` to avoid unsupported signing or audit claims.
+- Tightened release selector telemetry behavior and asset handling.
+
+## Template system
+
+`templatectl.sh render` and `templatectl.sh apply --dry-run` do not require a
+real Proxmox host. They validate the YAML, render the `qm` plan, and print the
+commands that would be used.
+
+Real `apply` still requires a Proxmox node because it runs `qm`. Commands are
+executed as argument arrays instead of shell strings. Raw `spec.vm.args` is
+restricted and only accepted when `policy.allowUnsafeArgs: true` is set in the
+template.
+
+The bundled templates are marked Experimental in this release. They validate
+and dry-run cleanly, but the non-dry-run VM creation path still needs testing
+against real Proxmox storage and bridge combinations.
+
+## Security notes
+
+- Removed `eval` from the template apply path.
+- Reduced command injection risk from YAML by validating VM IDs, VM names,
+  bridges, storage IDs, CPU strings, disk sizes, and raw args.
+- `SECURITY.md` now documents the guarantees the repository actually provides.
+- Release integrity is based on `SHA256SUMS`; no GPG-signed release assets are
+  claimed.
+
+## Validation performed
+
+The following checks passed in the maintainer workspace:
+
+```bash
+git diff --check
+bash -n scripts/pecu_release_selector.sh
+bash -n src/proxmox-configurator.sh
+bash -n src/tools/templatectl.sh
+bash -n src/tools/renderers/qm.sh
+CI=true scripts/validate_repo.sh
+grep -RIn --exclude-dir=.git '\beval\b' .
+src/tools/templatectl.sh render templates/windows/windows-gaming.yaml \
+  --vmid 200 \
+  --storage-pool local-lvm \
+  --dry-run
+```
+
+The Windows render output includes:
+
+- `--machine q35`
+- `--bios ovmf`
+- `--bootdisk scsi0`
+- `--efidisk0`
+- `--tpmstate0`
+- `--net0 virtio,bridge=vmbr0,firewall=1`
+
+## Known limitations
+
+- No real `qm create` was executed on a Proxmox node in this environment.
+- ShellCheck is enforced at error severity; warning-level debt in the larger
+  interactive scripts remains.
+- `src/proxmox-configurator.sh` is still a large interactive Bash script. This
+  release fixes targeted safety issues but does not rewrite it.
+- The template schema is intentionally conservative and may reject some valid
+  Proxmox edge cases until they are reviewed and added deliberately.
+
+## Recommended testing
+
+Run the repository validation locally:
+
+```bash
+CI=true scripts/validate_repo.sh
+```
+
+Preview the Windows template on the target host:
+
+```bash
+sudo src/tools/templatectl.sh apply templates/windows/windows-gaming.yaml \
+  --vmid 200 \
+  --storage-pool local-lvm \
+  --dry-run
+```
+
+Only after reviewing the dry-run plan, test a real apply on a non-production
+Proxmox node:
+
+```bash
+sudo src/tools/templatectl.sh apply templates/windows/windows-gaming.yaml \
+  --vmid 200 \
+  --storage-pool local-lvm
+
+qm config 200
+```
+
+## Upgrade notes
+
+Treat this as an Experimental release. Do not run it directly on production
+hosts without reviewing the dry-run output, checking backups, and keeping
+console or out-of-band access available.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,484 +1,96 @@
 # Security Policy
 
-**Proxmox Enhanced Configuration Utility (PECU)**  
-Repository: `Danilop95/Proxmox-Enhanced-Configuration-Utility`  
-License: GPL-3.0  
-Primary maintainer: [@Danilop95](https://github.com/Danilop95)  
+**Project:** Proxmox Enhanced Configuration Utility (PECU)
+**Repository:** `Danilop95/Proxmox-Enhanced-Configuration-Utility`
+**License:** GPL-3.0
+**Last updated:** May 11, 2026
 
----
+PECU is a Bash/Linux utility that can modify Proxmox host configuration as
+root. Treat every release as privileged system software: review the code, keep
+out-of-band console access, and test changes outside production first.
 
-## 1. Scope
+## Scope
 
-This security policy applies to all first-party content in this repository:
+This policy covers first-party files in this repository:
 
-| Component            | Description                                           | Language | Support Status |
-|----------------------|-------------------------------------------------------|----------|----------------|
-| `src/`               | Main script `proxmox-configurator.sh`                 | Bash     | Supported      |
-| `scripts/`           | Release selector and helper utilities                 | Bash     | Supported      |
-| GitHub Actions       | CI/CD workflows and automation                        | YAML     | Supported      |
-| `docs/`, wiki, README | End-user documentation                               | Markdown | Supported      |
-| Web interface        | Landing page and releases browser                     | HTML/JS  | Supported      |
+- `src/proxmox-configurator.sh`
+- `scripts/pecu_release_selector.sh`
+- `src/tools/templatectl.sh`
+- `src/tools/renderers/qm.sh`
+- `templates/`
+- `.github/workflows/`
+- project documentation
 
-**Out of scope:** Third-party software (Proxmox VE, Debian, driverctl, ROCm, NVIDIA drivers, etc.) must be reported to their respective upstream maintainers.
+Third-party software such as Proxmox VE, Debian, kernel modules, GPU drivers,
+`jq`, `yq`, `shellcheck`, Python packages, and GitHub infrastructure is out of
+scope and should be reported upstream.
 
----
+## Supported Versions
 
-## 2. Supported Versions
+Security fixes target the current `main` branch and the latest published Stable
+release when a fix can be backported safely. Older tags and experimental/beta
+release channels are best-effort only.
 
-**View all releases:** [Browse complete release history](https://danilop95.github.io/Proxmox-Enhanced-Configuration-Utility/releases.html)
+## Reporting a Vulnerability
 
-| PECU Channel | Security Support | Support Duration | Description |
-|--------------|------------------|------------------|-------------|
-| **Stable**   | **Full support** | 12 months | Complete security updates, bug fixes, and feature updates |
-| **Legacy**   | **Critical fixes only** | 6 months | Critical security patches and major bug fixes only |
-| **Beta**     | **No security support** | N/A | Development versions for testing purposes |
-| **Experimental** | **No security support** | N/A | Unstable features and proof-of-concept implementations |
-| **Deprecated** | **End of support** | N/A | No security updates or bug fixes provided |
+Preferred method:
 
-### Support Policy Details
+1. Open the repository **Security** tab on GitHub.
+2. Choose **Report a vulnerability**.
+3. Include affected version/tag, affected file, reproduction steps, expected
+   behavior, actual behavior, and impact.
 
-- **Stable Channel:** Latest stable releases receive comprehensive security support including all vulnerability patches, security enhancements, and compatibility updates
-- **Legacy Channel:** Previous stable versions receive only critical security fixes (CVSS >= 7.0) for a limited period
-- **Development Channels:** Beta and experimental releases are not supported for security issues and should not be used in production environments
-- **End of Life:** Deprecated versions receive no security updates and users must upgrade to supported versions
+If GitHub Security Advisories are unavailable, contact the maintainer through
+the public GitHub profile and request a private disclosure channel. Do not file
+public issues for exploitable vulnerabilities until coordinated disclosure is
+agreed.
 
-**Important:** Vulnerabilities in unsupported versions will not be patched. Organizations must upgrade to supported releases to maintain security coverage.
+## Response Expectations
 
----
+This is a small open-source project. Response is best-effort, not a guaranteed
+SLA. The maintainer will try to acknowledge credible reports promptly, triage
+impact, prepare a fix, and publish a release note or advisory when appropriate.
 
-## 3. Reporting Security Vulnerabilities
+## Release Integrity
 
-### Private Disclosure Process
+The release workflow is expected to publish:
 
-**Primary Method: GitHub Security Advisories**
-1. Navigate to the [Security tab](https://github.com/Danilop95/Proxmox-Enhanced-Configuration-Utility/security)
-2. Select "Report a vulnerability"
-3. Complete the advisory form with comprehensive details
+- a `PECU-<version>.tar.gz` bundle containing the runnable project structure
+- `SHA256SUMS` for release assets
 
-**Alternative Method: Email Disclosure**
-- Contact: **security@dvnilxp.dev**
-- PGP encryption recommended (key available upon request)
-- Include all required information detailed below
+Verify checksums when they are present:
 
-### Required Vulnerability Information
-
-```
-Subject: [SECURITY] PECU Vulnerability Report
-
-1. Vulnerability Description:
-   - Detailed technical description of the security issue
-   - Attack vector and exploitation methodology
-   - Potential impact assessment and affected systems
-
-2. Affected Components:
-   - PECU version or release tag
-   - Specific scripts or components affected
-   - Proxmox VE version compatibility
-
-3. System Environment:
-   - Operating system and kernel version
-   - Hardware configuration details
-   - Network configuration if relevant
-
-4. Reproduction Information:
-   - Step-by-step reproduction instructions
-   - Required privileges or system state
-   - Expected vs actual behavior
-
-5. Supporting Evidence:
-   - Proof-of-concept code or commands
-   - Log files or error messages
-   - Screenshots or system output
-
-6. Suggested Remediation:
-   - Proposed fix or mitigation strategy
-   - Workaround procedures if available
-   - Impact assessment of proposed changes
-
-7. Disclosure Preferences:
-   - Attribution preferences (credited or anonymous)
-   - Coordinated disclosure timeline requirements
+```bash
+sha256sum -c SHA256SUMS
 ```
 
-### Response Timeline Commitments
+This repository does **not** currently claim GPG-signed release assets or a
+published project signing key. Do not rely on old documentation or third-party
+copies that claim otherwise unless the release page explicitly provides those
+artifacts.
 
-| Phase | Standard Timeline | Critical Timeline | Description |
-|-------|------------------|-------------------|-------------|
-| **Initial Response** | 48 hours | 24 hours | Acknowledgment of vulnerability report |
-| **Preliminary Assessment** | 7 days | 72 hours | Initial impact and severity evaluation |
-| **Detailed Analysis** | 14 days | 7 days | Complete vulnerability analysis and CVSS scoring |
-| **Fix Development** | 30 days | 14 days | Patch development and internal testing |
-| **Public Disclosure** | 90 days | 30 days | Coordinated public advisory and release |
+## Safe-Use Guidance
 
-*Critical vulnerabilities are defined as CVSS >= 8.0 or those with active exploitation*
+- Prefer tagged releases over running the moving `main` branch.
+- Read scripts before running them as root.
+- Keep backups and console/IPMI access before changing bootloader, VFIO, or
+  initramfs configuration.
+- Use `src/tools/templatectl.sh apply --dry-run` before creating VMs from YAML
+  templates.
+- Run local validation before contributing:
 
----
-
-## 4. Security Patch Development Process
-
-### Standard Vulnerability Response
-
-| Phase | Objective | Timeline | Deliverables |
-|-------|-----------|----------|--------------|
-| **Triage** | Validate and categorize vulnerability | 1-3 days | Severity assessment, CVSS score |
-| **Analysis** | Detailed impact and root cause analysis | 3-7 days | Technical analysis, affected versions |
-| **Development** | Create and test security patch | 7-21 days | Patched code, regression testing |
-| **Review** | Security review and quality assurance | 2-5 days | Code review, security validation |
-| **Release** | Deploy patch and update documentation | 1-2 days | Security release, advisory publication |
-| **Post-Release** | Monitor deployment and gather feedback | Ongoing | Community feedback, additional fixes |
-
-### Critical Vulnerability Response
-
-For vulnerabilities meeting critical criteria:
-- **Immediate escalation** to primary maintainer
-- **24/7 response capability** during business hours
-- **Expedited development timeline** with dedicated resources
-- **Emergency release process** bypassing standard release cycles
-- **Coordinated disclosure** with major distributions and users
-
----
-
-## 5. Security Architecture and Controls
-
-### Code Security Measures
-
-**Input Validation and Sanitization**
-- All user inputs undergo strict validation and sanitization
-- Regular expression patterns for system identifiers and paths
-- Boundary checking for numerical inputs and system limits
-
-**Secure Coding Practices**
-- Bash strict mode (`set -Eeuo pipefail`) enforced across all scripts
-- Explicit error handling with detailed logging and recovery procedures
-- Minimal privilege principle with targeted sudo usage
-
-**Path and File Security**
-- Absolute path requirements for all file operations
-- Directory traversal prevention through path validation
-- Temporary file creation with secure permissions and cleanup
-
-### System Security Controls
-
-**Backup and Recovery**
-- Automatic system state backup before configuration changes
-- Rollback mechanisms for failed or problematic configurations
-- Configuration versioning and change tracking
-
-**Audit and Logging**
-- Comprehensive logging to `/var/log/pecu.log` with rotation
-- Security event logging including authentication and authorization
-- Audit trail maintenance for forensic analysis capabilities
-
-**Hardware Validation**
-- PCI device ID format validation and existence verification
-- Hardware compatibility checking before configuration changes
-- System resource validation and capacity planning
-
-### Release Security Framework
-
-**Code Signing and Verification**
-- GPG signing of all release tags and distribution packages
-- SHA256 checksum generation and verification for all assets
-- Cryptographic integrity verification throughout distribution chain
-
-**Release Channel Management**
-- Strict separation between stable, beta, and experimental channels
-- Automated testing and validation before channel promotion
-- Clear documentation of channel-specific security policies
-
-**Dependency Management**
-- Minimal external dependency requirements with version pinning
-- Regular security scanning of dependencies and base systems
-- Automated vulnerability detection in dependency chain
-
----
-
-## 6. Verification and Validation Procedures
-
-### Release Verification Commands
-
-```
-# Verify GPG signature of release tag
-git verify-tag v2025.06.20
-
-# Validate script integrity using checksums
-sha256sum -c checksums.txt
-
-# Verify detached GPG signature
-gpg --verify proxmox-configurator.sh.asc proxmox-configurator.sh
-
-# Check commit signature history
-git log --show-signature --oneline
+```bash
+scripts/validate_repo.sh
 ```
 
-### Security Validation Checklist
-
-**Pre-Installation Verification**
-- Verify GPG signatures of downloaded scripts
-- Validate checksums against published values
-- Review script contents for unexpected modifications
-- Confirm system compatibility and requirements
-
-**Post-Installation Validation**
-- Review generated configuration files
-- Verify system logs for errors or warnings
-- Test rollback procedures in non-production environment
-- Validate security controls and access restrictions
-
----
-
-## 7. User Security Guidelines
-
-### Production Environment Recommendations
-
-**Mandatory Security Practices**
-- Use only stable channel releases in production systems
-- Verify all downloads using provided cryptographic signatures
-- Maintain current backups before executing configuration changes
-- Test all changes in isolated development environments first
-
-**Access Control Requirements**
-- Limit administrative access to authorized personnel only
-- Implement multi-factor authentication for system access
-- Maintain audit logs of all administrative activities
-- Regular review of user access and permissions
-
-
-### Security Incident Response
-
-**Immediate Actions**
-- Preserve system logs and evidence for analysis
-- Contact security team using established communication channels
-- Document all actions taken during incident response
-
-**Recovery Procedures**
-- Use automated rollback capabilities to restore known-good state
-- Verify system integrity using checksums and signatures
-- Apply security patches before returning systems to production
-- Conduct post-incident review and documentation
-
----
-
-## 8. Exclusions and Limitations
-
-### Out-of-Scope Security Issues
-
-**External Software Components**
-- Vulnerabilities in Proxmox VE platform or underlying Debian system
-- Security issues in proprietary GPU drivers or firmware
-- Kernel vulnerabilities or hardware-specific security flaws
-- Third-party package vulnerabilities in system dependencies
-
-**User Configuration Issues**
-- Security misconfigurations introduced by end users
-- Unauthorized modifications to PECU scripts or configurations
-- Insecure system configurations outside PECU's scope
-- Hardware misconfigurations or compatibility issues
-
-**Infrastructure and Platform Issues**
-- GitHub platform security vulnerabilities
-- DNS, CDN, or hosting provider security issues
-- Client-side browser or operating system vulnerabilities
-
-### Limitation of Liability
-
-This security policy covers only the PECU software components directly maintained by the project team. Users are responsible for:
-- Maintaining secure system configurations
-- Applying security updates to underlying systems
-- Following established security best practices
-- Reporting suspected security issues promptly
-
----
-
-## 9. Security Community Recognition
-
-### Acknowledgment Process
-
-Security researchers who responsibly disclose vulnerabilities receive recognition through:
-
-**Public Acknowledgment**
-- Credit in release notes and security advisories
-- Recognition in project documentation and website
-- Optional CVE co-credit for significant discoveries
-
-**Hall of Fame Recognition**
-- Dedicated security contributors page
-- Annual recognition for outstanding contributions
-- Conference presentation opportunities where applicable
-
-**Communication and Feedback**
-- Direct communication with project maintainers
-- Feedback on security improvements and suggestions
-- Invitation to participate in security review processes
-
-### Recognition Criteria
-
-| Contribution Level | Recognition Type | Criteria |
-|-------------------|------------------|----------|
-| **Critical** | Featured acknowledgment | CVSS >= 8.0 or active exploitation |
-| **High** | Standard acknowledgment | CVSS 6.0-7.9 with significant impact |
-| **Medium** | Contributor recognition | CVSS 4.0-5.9 or security improvements |
-| **Low** | Documentation credit | Minor issues or documentation improvements |
-
-Anonymity preferences are respected and maintained throughout the recognition process.
-
----
-
-## 10. Cryptographic Standards and Key Management
-
-### GPG Signing Infrastructure
-
-**Primary Signing Key**
-\`\`\`
-Key ID: 3AA5C34371567BD2
-Algorithm: RSA 4096-bit
-Created: 2024-01-15
-Expires: 2026-01-15
-Fingerprint: 1234 5678 9ABC DEF0 1234 5678 3AA5 C343 7156 7BD2
-\`\`\`
-
-**Key Distribution and Verification**
-\`\`\`bash
-# Import from Ubuntu keyserver
-gpg --keyserver keyserver.ubuntu.com --recv-keys 3AA5C34371567BD2
-
-# Import from GitHub
-curl -sL https://github.com/Danilop95.gpg | gpg --import
-
-# Verify key fingerprint
-gpg --fingerprint 3AA5C34371567BD2
-\`\`\`
-
-**Signature Verification Examples**
-\`\`\`bash
-# Verify release tag signature
-git verify-tag v2025.06.20
-
-# Verify script signature
-gpg --verify proxmox-configurator.sh.sig proxmox-configurator.sh
-
-# Verify checksum file signature
-gpg --verify SHA256SUMS.asc SHA256SUMS
-\`\`\`
-
-### Cryptographic Standards Compliance
-
-**Hash Algorithms**
-- SHA-256 for file integrity verification
-- SHA-512 for password hashing where applicable
-- Blake2b for high-performance hashing requirements
-
-**Signature Algorithms**
-- RSA-4096 for release signing and verification
-- Ed25519 for commit signing where supported
-- ECDSA P-384 for alternative signature verification
-
----
-
-## 11. Compliance and Regulatory Alignment
-
-### Security Framework Compliance
-
-**Industry Standards**
-- OWASP Secure Coding Practices for script development
-- CIS Controls for Linux system hardening recommendations
-- NIST Cybersecurity Framework alignment for risk management
-- ISO 27001 security management principles integration
-
-**Regulatory Considerations**
-- GDPR compliance for any personal data handling
-- SOX compliance considerations for financial environments
-- HIPAA awareness for healthcare system deployments
-- PCI DSS considerations for payment processing environments
-
-### Audit and Assessment Schedule
-
-**Regular Security Activities**
-- Monthly automated vulnerability scanning
-- Quarterly manual security code review
-- Semi-annual penetration testing assessment
-- Annual third-party security audit
-
-**Continuous Monitoring**
-- Real-time dependency vulnerability monitoring
-- Automated security testing in CI/CD pipeline
-- Community vulnerability report monitoring
-- Threat intelligence integration and analysis
-
----
-
-## 12. Contact Information and Resources
-
-### Security Team Contacts
-
-**Primary Security Contact**
-- Maintainer: [@Danilop95](https://github.com/Danilop95)
-- Email: security@dvnilxp.dev
-- Response Hours: Monday-Friday, 09:00-17:00 CET
-- Emergency Response: Available for critical vulnerabilities
-
-**Alternative Communication Channels**
-- GitHub Security Advisories (preferred for vulnerability reports)
-- GitHub Issues (for non-sensitive security discussions)
-- Project Discussions (for security-related questions)
-
-### Project Resources
-
-**Documentation and Information**
-- Project Homepage: [PECU Landing Page](https://danilop95.github.io/Proxmox-Enhanced-Configuration-Utility/)
-- Release Browser: [All Releases](https://danilop95.github.io/Proxmox-Enhanced-Configuration-Utility/releases.html)
-- Issue Tracker: [GitHub Issues](https://github.com/Danilop95/Proxmox-Enhanced-Configuration-Utility/issues)
-- Community Forum: [GitHub Discussions](https://github.com/Danilop95/Proxmox-Enhanced-Configuration-Utility/discussions)
-
-**Security-Specific Resources**
-- Security Advisories: [GitHub Security Tab](https://github.com/Danilop95/Proxmox-Enhanced-Configuration-Utility/security)
-- Vulnerability Database: [GitHub Advisory Database](https://github.com/advisories)
-- Security Best Practices: [Project Wiki](https://github.com/Danilop95/Proxmox-Enhanced-Configuration-Utility/wiki)
-
----
-
-## 13. Policy Governance and Updates
-
-### Document Management
-
-This security policy is maintained under version control and updated regularly to reflect:
-- Changes in project scope and architecture
-- Evolution of security threats and best practices
-- Community feedback and security research findings
-- Regulatory and compliance requirement updates
-
-### Version History
-
-| Version | Date | Significant Changes |
-|---------|------|-------------------|
-| 3.0 | 2025-06-20 | Complete policy restructure, enhanced security controls |
-| 2.1 | 2025-06-17 | Added release browser integration, updated support matrix |
-| 2.0 | 2025-04-15 | Major revision with industry standard alignment |
-| 1.1 | 2025-02-01 | Added cryptographic verification procedures |
-| 1.0 | 2025-01-15 | Initial security policy establishment |
-
-### Review and Update Schedule
-
-**Regular Review Cycle**
-- Quarterly review of policy effectiveness and relevance
-- Annual comprehensive policy update and revision
-- Ad-hoc updates for significant security events or changes
-- Community input integration and feedback incorporation
-
-**Change Management Process**
-- All policy changes tracked in version control system
-- Security team review and approval for all modifications
-- Community notification for significant policy changes
-- Backward compatibility considerations for existing processes
-
----
-
-**Document Information**
-- **Last Updated:** June 20, 2025
-- **Next Scheduled Review:** September 20, 2025
-- **Policy Version:** 3.0
-- **Effective Date:** June 20, 2025
-
----
-
-*This security policy is maintained in accordance with industry best practices for open source software security and responsible disclosure principles.*
+## Sensitive Areas
+
+Security-sensitive changes should be reviewed carefully when they touch:
+
+- command execution from YAML/template input
+- release selector downloads or telemetry
+- `/etc/modprobe.d/*.conf`
+- `/etc/modules-load.d/*.conf`
+- `/etc/default/grub` and `/etc/kernel/cmdline`
+- VFIO device ID selection and SR-IOV PF/VF handling
+- GitHub Actions release packaging

--- a/scripts/pecu_release_selector.sh
+++ b/scripts/pecu_release_selector.sh
@@ -14,14 +14,14 @@
 #  
 #  Fixed Issues:
 #  - #18: Handles execution without sudo when running as root
-#  - #19: Improved jq installation with multiple fallback methods
+#  - #19: jq installation restricted to supported package managers
 #  - Better privilege detection and error handling
 #  - GDPR-compliant telemetry with explicit opt-in/opt-out
 #  - Privacy-friendly instance ID (random UUID, no fingerprinting)
 #  - Enhanced local development mode
 #  - Fixed: local variable used outside function scope
 #  - Fixed: Duplicated dependency installation restart block
-#  - Fixed: mkdir -p for jq installation to ~/.local/bin
+#  - Removed unverified direct jq binary installation fallback
 #  - Fixed: Robust UI functions that don't abort on terminal command failures
 #
 #  New Features (2025-12-11):
@@ -637,8 +637,8 @@ check_telemetry_consent() {
       echo -e "${C}║${NC}  ${B}PECU Anonymous Usage Statistics${NC}                         ${C}║${NC}" >&2
       echo -e "${C}╚═══════════════════════════════════════════════════════════════╝${NC}"
       echo ""
-      echo -e "${Y}PECU will send anonymous usage and environment metrics to help improve the software.${NC}"
-      echo -e "${Y}This can be disabled at any time.${NC}"
+      echo -e "${Y}PECU can send anonymous usage and environment metrics to help improve the software.${NC}"
+      echo -e "${Y}This is optional and disabled unless you explicitly opt in.${NC}"
       echo ""
       echo -e "${G}Data collected:${NC}"
       echo -e "  • Instance ID (random UUID, no personal info)"
@@ -670,22 +670,13 @@ check_telemetry_consent() {
       echo ""
       
       local answer
-      read -rp "Allow sending anonymous usage metrics? [Y/n] (default: Yes): " answer || answer=""
+      read -rp "Allow sending anonymous usage metrics? [y/N] (default: No): " answer || answer=""
       echo ""
       
       mkdir -p "$dir" 2>/dev/null || true
       
       case "${answer,,}" in
-        n|no)
-          printf 'disabled' > "$opt_file" 2>/dev/null || true
-          chmod 600 "$opt_file" 2>/dev/null || true
-          log_telemetry_event "CONSENT_DENIED" "User declined telemetry via interactive prompt"
-          echo -e "${Y}Telemetry disabled. You can enable it later by editing: ${C}$opt_file${NC}"
-          echo ""
-          return 1
-          ;;
-        *)
-          # Empty input or y/yes = consent (default is Yes)
+        y|yes)
           printf 'enabled' > "$opt_file" 2>/dev/null || true
           chmod 600 "$opt_file" 2>/dev/null || true
           log_telemetry_event "CONSENT_GRANTED" "User accepted telemetry via interactive prompt"
@@ -693,6 +684,14 @@ check_telemetry_consent() {
           echo -e "${Y}  You can disable it anytime: ${C}PECU_TELEMETRY=off${NC} or edit ${C}$opt_file${NC}"
           echo ""
           return 0
+          ;;
+        *)
+          printf 'disabled' > "$opt_file" 2>/dev/null || true
+          chmod 600 "$opt_file" 2>/dev/null || true
+          log_telemetry_event "CONSENT_DENIED" "User declined telemetry via interactive prompt"
+          echo -e "${Y}Telemetry disabled. You can enable it later by editing: ${C}$opt_file${NC}"
+          echo ""
+          return 1
           ;;
       esac
     else
@@ -1888,29 +1887,8 @@ for pkg in curl jq tar find awk sed; do
       echo -e "${G}Successfully installed $pkg${NC}"
     else
       if [[ "$pkg" == "jq" ]]; then
-        echo -e "${Y}Standard installation failed, trying alternative methods for jq…${NC}"
-        
-        if curl -fsSL "https://github.com/jqlang/jq/releases/latest/download/jq-linux64" -o "$WORKDIR/jq" 2>/dev/null; then
-          chmod +x "$WORKDIR/jq" 2>/dev/null
-          if "$WORKDIR/jq" --version &>/dev/null 2>&1; then
-            if run_as_admin cp "$WORKDIR/jq" /usr/local/bin/jq 2>/dev/null; then
-              echo -e "${G}Successfully installed jq via direct download${NC}"
-              continue
-            fi
-          fi
-        fi
-        
-        echo -e "${Y}Trying user-local installation for jq…${NC}"
-        mkdir -p "$HOME/.local/bin" 2>/dev/null || true
-        if curl -fsSL "https://github.com/jqlang/jq/releases/latest/download/jq-linux64" -o "$HOME/.local/bin/jq" 2>/dev/null; then
-          chmod +x "$HOME/.local/bin/jq" 2>/dev/null
-          if "$HOME/.local/bin/jq" --version &>/dev/null 2>&1; then
-            export PATH="$HOME/.local/bin:$PATH"
-            echo -e "${G}Successfully installed jq to user directory${NC}"
-            continue
-          fi
-        fi
-        
+        echo -e "${R}Failed to install jq with apt-get.${NC}"
+        echo -e "${Y}For security, PECU does not install unverified jq binaries from direct downloads.${NC}"
         if command -v snap &>/dev/null; then
           echo -e "${Y}Trying snap installation for jq…${NC}"
           if run_as_admin snap install jq 2>/dev/null; then
@@ -1919,11 +1897,10 @@ for pkg in curl jq tar find awk sed; do
           fi
         fi
         
-        echo -e "${R}Failed to install jq using all available methods.${NC}"
+        echo -e "${R}Failed to install jq using supported package managers.${NC}"
         echo -e "${Y}You can try installing it manually with one of these commands:${NC}"
         echo -e "  ${C}apt update && apt install jq${NC}"
         echo -e "  ${C}snap install jq${NC}"
-        echo -e "  ${C}wget https://github.com/jqlang/jq/releases/latest/download/jq-linux64 -O /usr/local/bin/jq && chmod +x /usr/local/bin/jq${NC}"
         exit 1
       else
         echo -e "${R}Failed to install $pkg.${NC}"
@@ -1940,10 +1917,7 @@ if ! command -v jq &>/dev/null || ! echo '{}' | jq . &>/dev/null; then
   echo -e "${Y}Please install jq manually using one of these methods:${NC}"
   echo -e "  ${C}# Method 1: Package manager (preferred)${NC}"
   echo -e "  ${C}apt update && apt install jq${NC}"
-  echo -e "  ${C}# Method 2: Direct download${NC}"
-  echo -e "  ${C}wget https://github.com/jqlang/jq/releases/latest/download/jq-linux64 -O /usr/local/bin/jq${NC}"
-  echo -e "  ${C}chmod +x /usr/local/bin/jq${NC}"
-  echo -e "  ${C}# Method 3: Snap (if available)${NC}"
+  echo -e "  ${C}# Method 2: Snap (if available)${NC}"
   echo -e "  ${C}snap install jq${NC}"
   exit 1
 fi
@@ -2094,42 +2068,103 @@ handle_ui_deps_and_execute() {
 
   send_pecu_telemetry
 
+  local RUN_ATTEMPTED=false
+
   run_raw() {
     local rel="$1"; [[ -n "${rel:-}" ]] || return 1
+    [[ "$rel" =~ ^(src/proxmox-configurator\.sh|proxmox-configurator\.sh)$ ]] || return 1
     local url="$RAW/$TAG/$rel"
     if curl -sfIL "$url" &>/dev/null; then
       local runner="$WORKDIR/runner.sh"
       if curl -fsSL "$url" -o "$runner" 2>/dev/null; then
         chmod +x "$runner" 2>/dev/null
-        (set +e; "$runner"; exit 0)
-        return 0
+        RUN_ATTEMPTED=true
+        (set +e; "$runner")
+        return $?
       fi
     fi
     return 1
   }
 
+  is_safe_asset_url() {
+    local url="$1"
+    [[ "$url" =~ ^https://github\.com/Danilop95/Proxmox-Enhanced-Configuration-Utility/releases/download/[^[:space:]]+/[^[:space:]]+\.tar\.gz$ ]]
+  }
+
+  safe_extract_tgz() {
+    local tgz="$1"
+    local dest="$2"
+    local entry
+
+    while IFS= read -r entry; do
+      case "$entry" in
+        /*|../*|*/../*|..|*/..)
+          echo -e "${R}Unsafe tar entry rejected: $entry${NC}" >&2
+          return 1
+          ;;
+      esac
+    done < <(tar -tzf "$tgz" 2>/dev/null)
+
+    tar --no-same-owner --no-same-permissions -xzf "$tgz" -C "$dest" 2>/dev/null
+  }
+
   run_asset() {
     [[ -n "${ASSET:-}" ]] || return 1
+    if ! is_safe_asset_url "$ASSET"; then
+      echo -e "${R}Release asset URL rejected: $ASSET${NC}" >&2
+      return 1
+    fi
+
     local tgz="$WORKDIR/pecu.tgz"
+    local asset_dir="$WORKDIR/asset"
+    mkdir -p "$asset_dir" 2>/dev/null || return 1
+
     curl -fsSL "$ASSET" -o "$tgz" 2>/dev/null || return 1
-    tar -xzf "$tgz" -C "$WORKDIR" 2>/dev/null || return 1
+    safe_extract_tgz "$tgz" "$asset_dir" || return 1
+
     local sh
-    sh=$(find "$WORKDIR" -name proxmox-configurator.sh -type f 2>/dev/null | head -n1 || true)
+    sh=$(find "$asset_dir" \( -path '*/src/proxmox-configurator.sh' -o -name 'proxmox-configurator.sh' \) -type f 2>/dev/null | sort | head -n1 || true)
     [[ -f "${sh:-}" ]] || return 1
     chmod +x "$sh" 2>/dev/null
-    (set +e; "$sh"; exit 0)
-    return 0
+    RUN_ATTEMPTED=true
+    (set +e; "$sh")
+    return $?
   }
 
   echo -e "${G}→ Executing $TAG …${NC}"
-  local START
-  START=$(date +%s)
-  run_raw "src/proxmox-configurator.sh"  || true
-  run_raw "proxmox-configurator.sh"      || true
+  local run_rc=1
 
-  if (( $(date +%s) - START < 3 )); then
-    echo -e "${Y}Script ended quickly — trying packaged asset…${NC}"
-    run_asset || true
+  if run_asset; then
+    run_rc=0
+  else
+    run_rc=$?
+  fi
+
+  if [[ "$RUN_ATTEMPTED" != "true" ]]; then
+    if run_raw "src/proxmox-configurator.sh"; then
+      run_rc=0
+    else
+      run_rc=$?
+    fi
+  fi
+
+  if [[ "$RUN_ATTEMPTED" != "true" ]]; then
+    if run_raw "proxmox-configurator.sh"; then
+      run_rc=0
+    else
+      run_rc=$?
+    fi
+  fi
+
+  if [[ "$RUN_ATTEMPTED" != "true" ]]; then
+    echo -e "${R}Could not download or execute the selected release safely.${NC}" >&2
+    echo -e "${Y}Checked release asset and raw script paths for tag: $TAG${NC}" >&2
+    return 1
+  fi
+
+  if (( run_rc != 0 )); then
+    echo -e "${R}Selected release exited with status $run_rc.${NC}" >&2
+    return "$run_rc"
   fi
   
   echo -e "\n${Y}Execution completed. Press Enter to continue…${NC}"

--- a/scripts/validate_repo.sh
+++ b/scripts/validate_repo.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+failures=0
+skips=0
+
+log() {
+  printf '%s\n' "$*"
+}
+
+ok() {
+  log "OK   $*"
+}
+
+warn() {
+  log "WARN $*"
+}
+
+fail() {
+  log "FAIL $*"
+  failures=$((failures + 1))
+}
+
+skip() {
+  log "SKIP $*"
+  skips=$((skips + 1))
+}
+
+have() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+strict_deps=false
+if [[ "${CI:-}" == "true" || "${PECU_VALIDATE_STRICT_DEPS:-}" == "true" ]]; then
+  strict_deps=true
+fi
+
+cd "$ROOT_DIR"
+
+scripts=(
+  "src/proxmox-configurator.sh"
+  "scripts/pecu_release_selector.sh"
+  "src/tools/templatectl.sh"
+  "src/tools/renderers/qm.sh"
+)
+
+log "== Bash syntax =="
+for script in "${scripts[@]}"; do
+  if bash -n "$script"; then
+    ok "bash -n $script"
+  else
+    fail "bash -n $script"
+  fi
+done
+
+log
+log "== ShellCheck =="
+if have shellcheck; then
+  if shellcheck -x -S error "${scripts[@]}"; then
+    ok "shellcheck -S error ${scripts[*]}"
+  else
+    fail "shellcheck reported error-severity issues"
+  fi
+else
+  if $strict_deps; then
+    fail "shellcheck no esta instalado"
+  else
+    skip "shellcheck no esta instalado; en CI se instala antes de ejecutar este script"
+  fi
+fi
+
+log
+log "== YAML lint =="
+if have yamllint; then
+  if yamllint templates .github/workflows; then
+    ok "yamllint templates .github/workflows"
+  else
+    fail "yamllint reported issues"
+  fi
+else
+  if $strict_deps; then
+    fail "yamllint no esta instalado"
+  else
+    skip "yamllint no esta instalado; en CI se instala antes de ejecutar este script"
+  fi
+fi
+
+log
+log "== Python modules =="
+if python3 - <<'PY'
+import jsonschema
+import yaml
+PY
+then
+  ok "Python modules jsonschema and PyYAML"
+else
+  fail "faltan modulos Python requeridos: jsonschema y/o PyYAML"
+fi
+
+log
+log "== Template schema validation =="
+if src/tools/templatectl.sh validate templates/; then
+  ok "templates validate against schema"
+else
+  fail "template schema validation failed"
+fi
+
+log
+log "== Renderer dry-run checks =="
+mapfile -t templates < <(find templates -type f -name '*.yaml' | sort)
+vmid=9000
+for template in "${templates[@]}"; do
+  output=""
+  if output="$(src/tools/templatectl.sh render "$template" --vmid "$vmid" --storage-pool local-lvm --dry-run 2>&1)"; then
+    ok "render $template"
+  else
+    printf '%s\n' "$output"
+    fail "render $template"
+    vmid=$((vmid + 1))
+    continue
+  fi
+
+  if grep -qE -- '--bootdisk[[:space:]]+(scsi|virtio|sata|ide)([[:space:]]|$)' <<<"$output"; then
+    fail "$template renders legacy bootdisk bus instead of concrete disk"
+  fi
+
+  if grep -q -- '^[[:space:]]*tpm:' "$template"; then
+    if grep -q -- '--tpmstate0' <<<"$output"; then
+      ok "TPM renders for $template"
+    else
+      fail "$template declares storage.tpm but render has no --tpmstate0"
+    fi
+  fi
+
+  if grep -q -- 'chipset: q35' "$template"; then
+    if grep -q -- '--machine q35' <<<"$output"; then
+      ok "q35 renders for $template"
+    elif grep -q -- 'allowMachinePin=false' <<<"$output"; then
+      ok "q35 omission documented for $template"
+    else
+      fail "$template declares q35 but render neither applies nor documents it"
+    fi
+  fi
+
+  if output="$(src/tools/templatectl.sh apply "$template" --vmid "$vmid" --storage-pool local-lvm --dry-run 2>&1)"; then
+    ok "apply --dry-run $template"
+  else
+    printf '%s\n' "$output"
+    fail "apply --dry-run $template"
+  fi
+
+  vmid=$((vmid + 1))
+done
+
+log
+log "== Renderer rejection checks =="
+tmp_template="$(mktemp "${TMPDIR:-/tmp}/pecu-bad-template.XXXXXX.yaml")"
+cat > "$tmp_template" <<'YAML'
+apiVersion: pecu.io/v1
+kind: VMTemplate
+metadata:
+  name: bad-unsafe-args
+  version: "2026.05.11"
+  channel: Experimental
+spec:
+  vm:
+    ostype: l26
+    name: bad-unsafe-args
+    cpu: host
+    sockets: 1
+    cores: 1
+    memoryMiB: 1024
+    chipset: q35
+    bios: ovmf
+    args: "-cpu host"
+  storage:
+    pool: local-lvm
+    bootdisk:
+      bus: scsi
+      sizeGiB: 8
+      format: raw
+  network:
+    - model: virtio
+      bridge: vmbr0
+      firewall: false
+  policy:
+    allowMachinePin: true
+    addUsbRootHub: false
+    allowUnsafeArgs: "false"
+YAML
+
+if src/tools/templatectl.sh render "$tmp_template" --vmid 9100 --storage-pool local-lvm >/dev/null 2>&1; then
+  fail "renderer accepted non-boolean allowUnsafeArgs with raw args"
+else
+  ok "renderer rejects non-boolean allowUnsafeArgs with raw args"
+fi
+rm -f "$tmp_template"
+
+log
+log "== Unsafe execution guard =="
+if grep -RInE '^[[:space:]]*eval([[:space:]]|$)' src scripts --include='*.sh'; then
+  fail "eval command found in executable shell scripts"
+else
+  ok "no eval command in executable shell scripts"
+fi
+
+log
+if (( failures > 0 )); then
+  log "Validation failed: $failures failure(s), $skips skipped check(s)."
+  exit 1
+fi
+
+log "Validation passed: $skips skipped check(s)."

--- a/src/proxmox-configurator.sh
+++ b/src/proxmox-configurator.sh
@@ -482,6 +482,43 @@ check_root() {
     fi
 }
 
+is_uint() {
+    [[ "${1:-}" =~ ^[0-9]+$ ]]
+}
+
+validate_int_range_or_msg() {
+    local value="$1"
+    local min="$2"
+    local max="$3"
+    local label="$4"
+
+    if ! is_uint "$value"; then
+        whiptail --title "Invalid Input" --msgbox "$label must be numeric." 8 60
+        return 1
+    fi
+
+    if (( value < min || value > max )); then
+        whiptail --title "Invalid Input" --msgbox "$label must be between $min and $max." 8 60
+        return 1
+    fi
+
+    return 0
+}
+
+validate_template_vmid_or_msg() {
+    validate_int_range_or_msg "$1" 100 999999999 "VM ID"
+}
+
+validate_template_vm_name_or_msg() {
+    local name="$1"
+    if [[ ! "$name" =~ ^[A-Za-z0-9][A-Za-z0-9-]{0,62}$ ]]; then
+        whiptail --title "Invalid Input" --msgbox \
+            "VM name must be 1-63 characters and use only letters, numbers, and hyphens. It must start with a letter or number." 10 75
+        return 1
+    fi
+    return 0
+}
+
 # Check system dependencies
 check_deps() {
     local missing=()
@@ -3045,20 +3082,25 @@ create_vm_templates() {
 create_windows_gaming_template() {
     local vmid name memory cores storage
 
-    vmid=$(whiptail --inputbox "Enter VM ID (100-999):" 8 40 "200" 3>&1 1>&2 2>&3)
+    vmid=$(whiptail --inputbox "Enter VM ID (>=100):" 8 40 "200" 3>&1 1>&2 2>&3)
     [[ -z "$vmid" ]] && return 1
+    validate_template_vmid_or_msg "$vmid" || return 1
 
     name=$(whiptail --inputbox "Enter VM name:" 8 40 "Windows-Gaming" 3>&1 1>&2 2>&3)
     [[ -z "$name" ]] && return 1
+    validate_template_vm_name_or_msg "$name" || return 1
 
     memory=$(whiptail --inputbox "RAM in MB:" 8 40 "16384" 3>&1 1>&2 2>&3)
     [[ -z "$memory" ]] && return 1
+    validate_int_range_or_msg "$memory" 512 1048576 "RAM in MB" || return 1
 
     cores=$(whiptail --inputbox "CPU cores:" 8 40 "8" 3>&1 1>&2 2>&3)
     [[ -z "$cores" ]] && return 1
+    validate_int_range_or_msg "$cores" 1 "$(nproc)" "CPU cores" || return 1
 
     storage=$(whiptail --inputbox "Disk size (GB):" 8 40 "120" 3>&1 1>&2 2>&3)
     [[ -z "$storage" ]] && return 1
+    validate_int_range_or_msg "$storage" 8 65536 "Disk size" || return 1
 
     log_info "Creating Windows Gaming VM template..."
 
@@ -3111,20 +3153,25 @@ create_windows_gaming_template() {
 create_linux_workstation_template() {
     local vmid name memory cores storage
 
-    vmid=$(whiptail --inputbox "Enter VM ID (100-999):" 8 40 "201" 3>&1 1>&2 2>&3)
+    vmid=$(whiptail --inputbox "Enter VM ID (>=100):" 8 40 "201" 3>&1 1>&2 2>&3)
     [[ -z "$vmid" ]] && return 1
+    validate_template_vmid_or_msg "$vmid" || return 1
 
     name=$(whiptail --inputbox "Enter VM name:" 8 40 "Linux-Workstation" 3>&1 1>&2 2>&3)
     [[ -z "$name" ]] && return 1
+    validate_template_vm_name_or_msg "$name" || return 1
 
     memory=$(whiptail --inputbox "RAM in MB:" 8 40 "32768" 3>&1 1>&2 2>&3)
     [[ -z "$memory" ]] && return 1
+    validate_int_range_or_msg "$memory" 512 1048576 "RAM in MB" || return 1
 
     cores=$(whiptail --inputbox "CPU cores:" 8 40 "16" 3>&1 1>&2 2>&3)
     [[ -z "$cores" ]] && return 1
+    validate_int_range_or_msg "$cores" 1 "$(nproc)" "CPU cores" || return 1
 
     storage=$(whiptail --inputbox "Disk size (GB):" 8 40 "200" 3>&1 1>&2 2>&3)
     [[ -z "$storage" ]] && return 1
+    validate_int_range_or_msg "$storage" 8 65536 "Disk size" || return 1
 
     log_info "Creating Linux Workstation VM template..."
 
@@ -3172,20 +3219,25 @@ create_linux_workstation_template() {
 create_media_server_template() {
     local vmid name memory cores storage
 
-    vmid=$(whiptail --inputbox "Enter VM ID (100-999):" 8 40 "202" 3>&1 1>&2 2>&3)
+    vmid=$(whiptail --inputbox "Enter VM ID (>=100):" 8 40 "202" 3>&1 1>&2 2>&3)
     [[ -z "$vmid" ]] && return 1
+    validate_template_vmid_or_msg "$vmid" || return 1
 
     name=$(whiptail --inputbox "Enter VM name:" 8 40 "Media-Server" 3>&1 1>&2 2>&3)
     [[ -z "$name" ]] && return 1
+    validate_template_vm_name_or_msg "$name" || return 1
 
     memory=$(whiptail --inputbox "RAM in MB:" 8 40 "8192" 3>&1 1>&2 2>&3)
     [[ -z "$memory" ]] && return 1
+    validate_int_range_or_msg "$memory" 512 1048576 "RAM in MB" || return 1
 
     cores=$(whiptail --inputbox "CPU cores:" 8 40 "4" 3>&1 1>&2 2>&3)
     [[ -z "$cores" ]] && return 1
+    validate_int_range_or_msg "$cores" 1 "$(nproc)" "CPU cores" || return 1
 
     storage=$(whiptail --inputbox "Disk size (GB):" 8 40 "50" 3>&1 1>&2 2>&3)
     [[ -z "$storage" ]] && return 1
+    validate_int_range_or_msg "$storage" 8 65536 "Disk size" || return 1
 
     log_info "Creating Media Server VM template..."
 
@@ -3237,11 +3289,10 @@ create_custom_template() {
     local vmid name memory cores storage ostype cpu_type
 
     while true; do
-        vmid=$(whiptail --inputbox "Enter VM ID (100-999):" 8 40 "300" 3>&1 1>&2 2>&3)
+        vmid=$(whiptail --inputbox "Enter VM ID (>=100):" 8 40 "300" 3>&1 1>&2 2>&3)
         [[ -z "$vmid" ]] && return 1
 
-        if [[ "$vmid" -lt 100 || "$vmid" -gt 999 ]]; then
-            whiptail --title "Invalid Input" --msgbox "VM ID must be between 100-999." 8 60
+        if ! validate_template_vmid_or_msg "$vmid"; then
             continue
         fi
 
@@ -3254,12 +3305,12 @@ create_custom_template() {
 
     name=$(whiptail --inputbox "Enter VM name:" 8 50 "Custom-Template" 3>&1 1>&2 2>&3)
     [[ -z "$name" ]] && return 1
+    validate_template_vm_name_or_msg "$name" || return 1
 
     while true; do
         memory=$(whiptail --inputbox "RAM in MB (min 512):" 8 50 "4096" 3>&1 1>&2 2>&3)
         [[ -z "$memory" ]] && return 1
-        if [[ "$memory" -lt 512 ]]; then
-            whiptail --title "Invalid Input" --msgbox "Memory must be at least 512 MB." 8 60
+        if ! validate_int_range_or_msg "$memory" 512 1048576 "RAM in MB"; then
             continue
         fi
         break
@@ -3270,8 +3321,7 @@ create_custom_template() {
     while true; do
         cores=$(whiptail --inputbox "CPU cores (max $max_cores):" 8 50 "2" 3>&1 1>&2 2>&3)
         [[ -z "$cores" ]] && return 1
-        if [[ "$cores" -lt 1 || "$cores" -gt "$max_cores" ]]; then
-            whiptail --title "Invalid Input" --msgbox "CPU cores must be between 1-$max_cores." 8 60
+        if ! validate_int_range_or_msg "$cores" 1 "$max_cores" "CPU cores"; then
             continue
         fi
         break
@@ -3279,6 +3329,7 @@ create_custom_template() {
 
     storage=$(whiptail --inputbox "Disk size (GB):" 8 50 "32" 3>&1 1>&2 2>&3)
     [[ -z "$storage" ]] && return 1
+    validate_int_range_or_msg "$storage" 8 65536 "Disk size" || return 1
 
     ostype=$(whiptail --title "OS Type" --menu "Select OS type:" 15 70 4 \
         "l26" "Linux 2.6/3.x/4.x/5.x kernel" \

--- a/src/tools/renderers/qm.sh
+++ b/src/tools/renderers/qm.sh
@@ -1,199 +1,386 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# qm.sh — traduce un YAML de plantilla P  local efi_size efi_prek tmp_size tmp_ver
-  efi_size="$(yget "$file" '.spec.storage.efi.sizeGiB // 0')"
-  efi_prek="$(yget "$file" '.spec.storage.efi.preEnrolledKeys // false')"
-  tmp_size="$(yget "$file" '.spec.storage.tpm.sizeGiB // 0')"
-  tmp_ver="$(yget "$file" '.spec.storage.tpm.version // ""')" una serie de comandos 'qm'
-# No ejecuta nada: escribe a STDOUT una lista de comandos, uno por línea.
-# Flags:
-#   --file <path.yaml> (obligatorio)
-#   --vmid <id>        (obligatorio)
-#   --storage-pool <auto|local-lvm|local>  (opcional; sobreescribe YAML)
-#   --disk-size <GiB>  (opcional; sobreescribe tamaño de bootdisk)
-#   --dry-run          (ignorado aquí; el renderer siempre es no-ejecutable)
+# qm.sh - renderiza una plantilla PECU como comandos qm seguros.
+#
+# Este renderer no ejecuta nada. Puede emitir:
+#   --format human  comandos shell-quoted para lectura/dry-run
+#   --format json   JSON estructurado con arrays argv para ejecucion segura
 
-have() { command -v "$1" >/dev/null 2>&1; }
-
-die() { echo "ERROR: $*" >&2; exit 1; }
-
-yget() { yq eval "$2" "$1"; }
-
-detect_pool() {
-  # Detección simple: si existe 'local-lvm' con content images, usarlo; si no, 'local'.
-  if have pvesm; then
-    if pvesm status | awk '{print $1,$5}' | grep -qE '^local-lvm .*images'; then
-      echo "local-lvm"; return
-    fi
-    if pvesm status | awk '{print $1,$5}' | grep -qE '^local .*images'; then
-      echo "local"; return
-    fi
-  fi
-  # Fallback conservador
-  echo "local-lvm"
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
 }
 
-ensure_tools() {
-  for t in yq jq awk sed; do
-    command -v "$t" >/dev/null 2>&1 || die "Falta herramienta: $t"
-  done
+command -v python3 >/dev/null 2>&1 || die "Falta herramienta: python3"
+
+python3 - "$@" <<'PY'
+import argparse
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+
+try:
+    import yaml
+except Exception as exc:
+    print(f"ERROR: falta Python module PyYAML: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+
+VMID_RE = re.compile(r"^[0-9]+$")
+VM_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]{0,62}$")
+STORAGE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
+BRIDGE_RE = re.compile(r"^vmbr[0-9]{1,4}$")
+CPU_RE = re.compile(r"^[A-Za-z0-9_.+-]+(,[A-Za-z0-9_.+-]+(=[A-Za-z0-9_.:+-]+)?)*$")
+ARGS_RE = re.compile(r"^[A-Za-z0-9_.,=:+\-/ ]{1,512}$")
+INT_RE = re.compile(r"^[0-9]+$")
+
+OSTYPES = {
+    "l24", "l26", "solaris", "other",
+    "win7", "win8", "win10", "win11", "w2k", "w2k3", "w2k8", "wvista", "wxp",
 }
 
-main() {
-  ensure_tools
+BUS_TYPES = {"scsi", "virtio", "sata", "ide"}
+DISK_FORMATS = {"raw", "qcow2"}
+NIC_MODELS = {"virtio", "e1000", "vmxnet3", "rtl8139"}
 
-  local file="" vmid="" pool_override="" disk_override="" dry="false"
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --file) file="${2:-}"; shift 2;;
-      --vmid) vmid="${2:-}"; shift 2;;
-      --storage-pool) pool_override="${2:-}"; shift 2;;
-      --disk-size) disk_override="${2:-}"; shift 2;;
-      --dry-run) dry="true"; shift 1;;
-      *) die "Flag desconocido: $1";;
-    esac
-  done
-  [[ -f "$file" ]] || die "No existe YAML: $file"
-  [[ -n "$vmid" ]] || die "--vmid obligatorio"
 
-  # Extrae campos
-  local name ostype cpu sockets cores mem bios chipset tablet args
-  name="$(yget "$file" '.spec.vm.name // .metadata.name')"
-  ostype="$(yget "$file" '.spec.vm.ostype')"
-  cpu="$(yget "$file" '.spec.vm.cpu')"
-  sockets="$(yget "$file" '.spec.vm.sockets')"
-  cores="$(yget "$file" '.spec.vm.cores')"
-  mem="$(yget "$file" '.spec.vm.memoryMiB')"
-  bios="$(yget "$file" '.spec.vm.bios')"
-  chipset="$(yget "$file" '.spec.vm.chipset')"
-  tablet="$(yget "$file" '.spec.vm.tablet // false')"
-  args="$(yget "$file" '.spec.vm.args // ""')"
+def die(message):
+    print(f"ERROR: {message}", file=sys.stderr)
+    sys.exit(1)
 
-  local pool yaml_pool bus size format
-  yaml_pool="$(yget "$file" '.spec.storage.pool')"
-  pool="$yaml_pool"
-  [[ -n "$pool_override" ]] && pool="$pool_override"
-  [[ "$pool" == "auto" || -z "$pool" ]] && pool="$(detect_pool)"
 
-  bus="$(yget "$file" '.spec.storage.bootdisk.bus')"
-  size="$(yget "$file" '.spec.storage.bootdisk.sizeGiB')"
-  format="$(yget "$file" '.spec.storage.bootdisk.format // "raw"')"
-  [[ -n "$disk_override" ]] && size="$disk_override"
+def warn(warnings, message):
+    warnings.append(message)
+    print(f"WARN: {message}", file=sys.stderr)
 
-  local efi_size efi_prek tpm_size tmp_ver
-  efi_size="$(yget "$file" '.spec.storage.efi.sizeGiB // 0')"
-  efi_prek="$(yget "$file" '.spec.storage.efi.preEnrolledKeys // false')"
-  tmp_size="$(yget "$file" '.spec.storage.tmp.sizeGiB // 0')"
-  tmp_ver="$(yget "$file" '.spec.storage.tmp.version // ""')"
 
-  local nic_count nic_model nic_bridge nic_fw
-  nic_count="$(yq eval '.spec.network | length' "$file")"
+def load_template(path):
+    with open(path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if not isinstance(data, dict):
+        die(f"Plantilla vacia o invalida: {path}")
+    return data
 
-  local allow_machine add_usb
-  allow_machine="$(yget "$file" '.spec.policy.allowMachinePin')"
-  add_usb="$(yget "$file" '.spec.policy.addUsbRootHub')"
 
-  # Build qm create command as string
-  local create_cmd="qm create ${vmid}"
-  create_cmd+=" --name ${name}"
-  create_cmd+=" --ostype ${ostype}"
-  create_cmd+=" --cpu '${cpu}'"
-  create_cmd+=" --sockets ${sockets}"
-  create_cmd+=" --cores ${cores}"
-  create_cmd+=" --memory ${mem}"
-  create_cmd+=" --scsihw virtio-scsi-single"
+def get(mapping, dotted, default=None):
+    cur = mapping
+    for part in dotted.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return default
+        cur = cur[part]
+    return cur
 
-  if [[ "$bios" == "ovmf" ]]; then
-    create_cmd+=" --bios ovmf"
-    # UEFI requiere máquina Q35 habitualmente, pero NO fijamos --machine si policy no lo permite
-  else
-    create_cmd+=" --bios seabios"
-  fi
 
-  if [[ "${tablet}" == "true" ]]; then
-    create_cmd+=" --tablet 1"
-  else
-    create_cmd+=" --tablet 0"
-  fi
+def parse_int(value, field, minimum=None, maximum=None):
+    if isinstance(value, bool):
+        die(f"{field} debe ser numerico")
+    if isinstance(value, int):
+        num = value
+    elif isinstance(value, str) and INT_RE.match(value):
+        num = int(value)
+    else:
+        die(f"{field} debe ser numerico")
 
-  if [[ -n "$args" && "$args" != "null" ]]; then
-    create_cmd+=" --args \"$args\""
-  fi
+    if minimum is not None and num < minimum:
+        die(f"{field} debe ser >= {minimum}")
+    if maximum is not None and num > maximum:
+        die(f"{field} debe ser <= {maximum}")
+    return num
 
-  # Discos: bootdisk
-  # En local-lvm: 'pool:size' sin format
-  # En local (directory): usamos format si es raw o qcow2
-  local disk_arg=""
-  case "$pool" in
-    local-lvm)
-      disk_arg="${pool}:${size}"
-      ;;
-    local)
-      # Para directory storage permitimos format=raw/qcow2
-      disk_arg="${pool}:${size},format=${format}"
-      ;;
-    *)
-      # Para otros storages (si existen), usamos la sintaxis simple
-      disk_arg="${pool}:${size}"
-      ;;
-  esac
 
-  # Mapea bus → <bus>0
-  local bootdisk="${bus}0"
-  create_cmd+=" --${bootdisk} ${disk_arg}"
-  create_cmd+=" --bootdisk ${bus}"
+def parse_bool(value, field, default=None):
+    if value is None:
+        if default is None:
+            die(f"{field} debe ser booleano")
+        return default
+    if not isinstance(value, bool):
+        die(f"{field} debe ser booleano")
+    return value
 
-  # NICs
-  # Añadimos en create para la primera NIC; siguientes con qm set
-  if (( nic_count > 0 )); then
-    nic_model="$(yq eval '.spec.network[0].model' "$file")"
-    nic_bridge="$(yq eval '.spec.network[0].bridge' "$file")"
-    nic_fw="$(yq eval '.spec.network[0].firewall // false' "$file")"
-    local net0="model=${nic_model},bridge=${nic_bridge}"
-    [[ "$nic_fw" == "true" ]] && net0="${net0},firewall=1"
-    create_cmd+=" --net0 ${net0}"
-  fi
 
-  # Output the main create command
-  echo "$create_cmd"
+def validate_vmid(value):
+    if not isinstance(value, str) or not VMID_RE.fullmatch(value):
+        die("--vmid debe ser numerico")
+    vmid = int(value)
+    if vmid < 100 or vmid > 999999999:
+        die("--vmid debe estar entre 100 y 999999999")
+    return str(vmid)
 
-  # 4) NICs adicionales (net1, net2…)
-  if (( nic_count > 1 )); then
-    for i in $(seq 1 $((nic_count-1))); do
-      nic_model="$(yq eval ".spec.network[$i].model" "$file")"
-      nic_bridge="$(yq eval ".spec.network[$i].bridge" "$file")"
-      nic_fw="$(yq eval ".spec.network[$i].firewall // false" "$file")"
-      local neti="model=${nic_model},bridge=${nic_bridge}"
-      [[ "$nic_fw" == "true" ]] && neti="${neti},firewall=1"
-      echo "qm set ${vmid} --net${i} ${neti}"
-    done
-  fi
 
-  # 5) EFI / TPM (si proceden)
-  if [[ "$bios" == "ovmf" && "$efi_size" != "0" ]]; then
-    local efidisk="${pool}:${efi_size}"
-    # pre-enrolled-keys=1 si procede
-    if [[ "$efi_prek" == "true" ]]; then
-      efidisk="${efidisk},pre-enrolled-keys=1"
-    fi
-    echo "qm set ${vmid} --efidisk0 ${efidisk}"
-  fi
+def validate_regex(value, regex, field):
+    if not isinstance(value, str) or not regex.fullmatch(value):
+        die(f"{field} tiene formato inseguro o no soportado: {value!r}")
+    return value
 
-  if [[ "$tmp_size" != "0" && -n "$tmp_ver" ]]; then
-    local tpmarg="${pool}:${tmp_size},version=${tmp_ver}"
-    echo "qm set ${vmid} --tpmstate0 ${tpmarg}"
-  fi
 
-  # 6) Política: machine pin / usb root hub (por defecto NO)
-  if [[ "$allow_machine" != "true" ]]; then
-    # No hacemos nada: evitamos --machine fijo
-    :
-  fi
-  if [[ "$add_usb" == "true" ]]; then
-    # Si el usuario lo forzara explícitamente (no recomendado)
-    echo "qm set ${vmid} --usb0 host=1d6b:0002"
-  fi
-}
+def detect_pool(warnings):
+    pvesm = shutil.which("pvesm")
+    if not pvesm:
+        warn(warnings, "pvesm no esta disponible; usando fallback local-lvm para render no-Proxmox")
+        return "local-lvm"
 
-main "$@"
+    try:
+        proc = subprocess.run(
+            [pvesm, "status", "--content", "images"],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        warn(warnings, "no se pudo ejecutar pvesm; usando fallback local-lvm")
+        return "local-lvm"
+
+    if proc.returncode != 0:
+        warn(warnings, "pvesm status fallo; usando fallback local-lvm")
+        return "local-lvm"
+
+    storage_names = []
+    for line in proc.stdout.splitlines()[1:]:
+        parts = line.split()
+        if not parts:
+            continue
+        storage_names.append(parts[0])
+
+    if "local-lvm" in storage_names:
+        return "local-lvm"
+    if "local" in storage_names:
+        return "local"
+
+    warn(warnings, "no se encontro storage images local/local-lvm; usando fallback local-lvm")
+    return "local-lvm"
+
+
+def disk_volume_arg(pool, size_gib, disk_format):
+    if pool == "local":
+        return f"{pool}:{size_gib},format={disk_format}"
+    return f"{pool}:{size_gib}"
+
+
+def efi_volume_arg(pool, size_gib, disk_format, pre_enrolled_keys):
+    parts = [f"{pool}:{size_gib}"]
+    if pool == "local":
+        parts.append(f"format={disk_format}")
+    parts.append("efitype=4m")
+    parts.append(f"pre-enrolled-keys={1 if pre_enrolled_keys else 0}")
+    return ",".join(parts)
+
+
+def tpm_volume_arg(pool, size_gib, version):
+    return f"{pool}:{size_gib},version={version}"
+
+
+def net_arg(nic):
+    model = validate_regex(nic.get("model"), re.compile(r"^(virtio|e1000|vmxnet3|rtl8139)$"), "network.model")
+    bridge = validate_regex(nic.get("bridge"), BRIDGE_RE, "network.bridge")
+    arg = f"{model},bridge={bridge}"
+    if parse_bool(nic.get("firewall"), "network.firewall", default=False):
+        arg += ",firewall=1"
+    return arg
+
+
+def build_commands(data, args):
+    warnings = []
+    vmid = validate_vmid(args.vmid)
+
+    metadata_name = get(data, "metadata.name")
+    vm = get(data, "spec.vm", {})
+    storage = get(data, "spec.storage", {})
+    policy = get(data, "spec.policy", {})
+    network = get(data, "spec.network", [])
+
+    if not isinstance(vm, dict) or not isinstance(storage, dict):
+        die("spec.vm y spec.storage son obligatorios")
+    if not isinstance(policy, dict):
+        die("spec.policy es obligatorio")
+    if not isinstance(network, list) or not network:
+        die("spec.network debe contener al menos una NIC")
+
+    name = vm.get("name") or metadata_name
+    validate_regex(name, VM_NAME_RE, "spec.vm.name")
+
+    ostype = vm.get("ostype")
+    if ostype not in OSTYPES:
+        die(f"spec.vm.ostype no soportado: {ostype!r}")
+
+    cpu = validate_regex(vm.get("cpu"), CPU_RE, "spec.vm.cpu")
+    sockets = parse_int(vm.get("sockets"), "spec.vm.sockets", 1, 8)
+    cores = parse_int(vm.get("cores"), "spec.vm.cores", 1, 512)
+    memory = parse_int(vm.get("memoryMiB"), "spec.vm.memoryMiB", 256, 1048576)
+
+    bios = vm.get("bios")
+    if bios not in {"ovmf", "seabios"}:
+        die(f"spec.vm.bios no soportado: {bios!r}")
+
+    chipset = vm.get("chipset", "auto")
+    if chipset not in {"q35", "i440fx", "auto"}:
+        die(f"spec.vm.chipset no soportado: {chipset!r}")
+
+    allow_machine_pin = parse_bool(policy.get("allowMachinePin"), "spec.policy.allowMachinePin")
+    add_usb_root_hub = parse_bool(policy.get("addUsbRootHub"), "spec.policy.addUsbRootHub")
+    allow_unsafe_args = parse_bool(policy.get("allowUnsafeArgs"), "spec.policy.allowUnsafeArgs")
+
+    raw_args = vm.get("args")
+    if raw_args in (None, "", "null"):
+        raw_args = ""
+    elif not allow_unsafe_args:
+        die("spec.vm.args requiere spec.policy.allowUnsafeArgs: true")
+    else:
+        validate_regex(raw_args, ARGS_RE, "spec.vm.args")
+
+    yaml_pool = storage.get("pool", "auto")
+    if args.storage_pool:
+        pool = args.storage_pool
+    else:
+        pool = yaml_pool
+    if not isinstance(pool, str):
+        die("spec.storage.pool debe ser string")
+    if pool == "auto":
+        pool = detect_pool(warnings)
+    validate_regex(pool, STORAGE_RE, "storage pool")
+
+    bootdisk = storage.get("bootdisk", {})
+    if not isinstance(bootdisk, dict):
+        die("spec.storage.bootdisk es obligatorio")
+
+    bus = bootdisk.get("bus")
+    if bus not in BUS_TYPES:
+        die(f"spec.storage.bootdisk.bus no soportado: {bus!r}")
+    disk_name = f"{bus}0"
+
+    size_value = args.disk_size if args.disk_size else bootdisk.get("sizeGiB")
+    size_gib = parse_int(size_value, "boot disk size", 8, 65536)
+    disk_format = bootdisk.get("format", "raw")
+    if disk_format not in DISK_FORMATS:
+        die(f"spec.storage.bootdisk.format no soportado: {disk_format!r}")
+
+    tablet = "1" if parse_bool(vm.get("tablet"), "spec.vm.tablet", default=False) else "0"
+
+    create = [
+        "qm", "create", vmid,
+        "--name", name,
+        "--ostype", ostype,
+        "--cpu", cpu,
+        "--sockets", str(sockets),
+        "--cores", str(cores),
+        "--memory", str(memory),
+        "--scsihw", "virtio-scsi-single",
+        "--bios", bios,
+        "--tablet", tablet,
+    ]
+
+    if chipset != "auto":
+        if allow_machine_pin:
+            machine = "q35" if chipset == "q35" else "pc"
+            create.extend(["--machine", machine])
+        else:
+            warn(
+                warnings,
+                f"spec.vm.chipset={chipset} no se aplica porque allowMachinePin=false",
+            )
+
+    if raw_args:
+        create.extend(["--args", raw_args])
+
+    create.extend([f"--{disk_name}", disk_volume_arg(pool, size_gib, disk_format)])
+    create.extend(["--bootdisk", disk_name])
+    create.extend(["--net0", net_arg(network[0])])
+
+    commands = [{"argv": create, "description": "create VM"}]
+
+    for idx, nic in enumerate(network[1:], start=1):
+        commands.append(
+            {
+                "argv": ["qm", "set", vmid, f"--net{idx}", net_arg(nic)],
+                "description": f"set net{idx}",
+            }
+        )
+
+    efi = storage.get("efi")
+    if bios == "ovmf" and isinstance(efi, dict):
+        efi_size = parse_int(efi.get("sizeGiB", 0), "spec.storage.efi.sizeGiB", 0, 64)
+        if efi_size > 0:
+            efi_prek = parse_bool(efi.get("preEnrolledKeys"), "spec.storage.efi.preEnrolledKeys", default=False)
+            commands.append(
+                {
+                    "argv": [
+                        "qm", "set", vmid,
+                        "--efidisk0",
+                        efi_volume_arg(pool, efi_size, disk_format, efi_prek),
+                    ],
+                    "description": "set UEFI disk",
+                }
+            )
+    elif bios == "ovmf":
+        warn(warnings, "bios=ovmf sin spec.storage.efi; Proxmox puede crear una VM UEFI incompleta")
+
+    tpm = storage.get("tpm")
+    if isinstance(tpm, dict):
+        tpm_size = parse_int(tpm.get("sizeGiB", 0), "spec.storage.tpm.sizeGiB", 0, 64)
+        tpm_version = tpm.get("version")
+        if tpm_size > 0:
+            if tpm_version != "v2.0":
+                die("spec.storage.tpm.version debe ser v2.0")
+            commands.append(
+                {
+                    "argv": [
+                        "qm", "set", vmid,
+                        "--tpmstate0",
+                        tpm_volume_arg(pool, tpm_size, tpm_version),
+                    ],
+                    "description": "set TPM state",
+                }
+            )
+
+    if add_usb_root_hub:
+        commands.append(
+            {
+                "argv": ["qm", "set", vmid, "--usb0", "host=1d6b:0002"],
+                "description": "set USB root hub",
+            }
+        )
+
+    return {"commands": commands, "warnings": warnings}
+
+
+def emit_human(result):
+    for message in result["warnings"]:
+        print(f"# WARNING: {message}")
+    for command in result["commands"]:
+        desc = command.get("description")
+        if desc:
+            print(f"# {desc}")
+        print(shlex.join(command["argv"]))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="PECU qm renderer")
+    parser.add_argument("--file", required=True)
+    parser.add_argument("--vmid", required=True)
+    parser.add_argument("--storage-pool", default="")
+    parser.add_argument("--disk-size", default="")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--format", choices=["human", "json"], default="human")
+    parsed = parser.parse_args()
+
+    if not os.path.isfile(parsed.file):
+        die(f"No existe YAML: {parsed.file}")
+
+    data = load_template(parsed.file)
+    result = build_commands(data, parsed)
+
+    if parsed.format == "json":
+        json.dump(result, sys.stdout, separators=(",", ":"))
+        print()
+    else:
+        emit_human(result)
+
+
+if __name__ == "__main__":
+    main()
+PY

--- a/src/tools/templatectl.sh
+++ b/src/tools/templatectl.sh
@@ -1,26 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# templatectl.sh — CLI para listar, validar, renderizar y aplicar plantillas PECU
-# Requisitos: bash, jq, yq (v4), python3 (jsonschema, pyyaml), find, grep, awk
-# Uso: templatectl.sh <list|validate|render|apply> [args]
-# Ejemplos:
-#   templatectl.sh list --channel Stable
-#   templatectl.sh validate templates/
-#   templatectl.sh render templates/windows/windows-gaming.yaml --vmid 200 --storage-pool local-lvm --dry-run
-#   sudo templatectl.sh apply templates/windows/windows-gaming.yaml --vmid 200 --storage-pool local-lvm
+# templatectl.sh - CLI para listar, validar, renderizar y aplicar plantillas PECU.
+# Requisitos:
+#   - list/render: bash, python3, PyYAML
+#   - validate:    python3, PyYAML, jsonschema
+#   - apply:       qm en Proxmox real; no usa eval ni shell para ejecutar comandos
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 SCHEMA_PATH="${REPO_ROOT}/templates/schemas/template.schema.json"
 RENDERER="${SCRIPT_DIR}/renderers/qm.sh"
 
-die() { echo "ERROR: $*" >&2; exit 1; }
-have() { command -v "$1" >/dev/null 2>&1; }
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+have() {
+  command -v "$1" >/dev/null 2>&1
+}
 
 require_tools() {
   local missing=()
-  for t in "$@"; do have "$t" || missing+=("$t"); done
+  local tool
+  for tool in "$@"; do
+    have "$tool" || missing+=("$tool")
+  done
   if (( ${#missing[@]} )); then
     die "Faltan herramientas: ${missing[*]}"
   fi
@@ -28,178 +34,338 @@ require_tools() {
 
 usage() {
   cat <<'EOF'
-templatectl.sh — gestiona VM templates (PECU)
+templatectl.sh - gestiona VM templates (PECU)
 
 Comandos:
   list [--channel <Stable|Beta|Experimental>] [--path <dir>]
   validate <path|file>
-  render <file.yaml> --vmid <id> [--storage-pool <auto|local-lvm|local>] [--disk-size <GiB>] [--dry-run]
-  apply  <file.yaml> --vmid <id> [--storage-pool <auto|local-lvm|local>] [--disk-size <GiB>] [--no-convert-template] [--dry-run]
+  render <file.yaml> --vmid <id> [--storage-pool <auto|pool>] [--disk-size <GiB>] [--dry-run]
+  apply  <file.yaml> --vmid <id> [--storage-pool <auto|pool>] [--disk-size <GiB>] [--no-convert-template] [--dry-run]
 
 Flags comunes:
-  --vmid N                 VMID obligatorio para render/apply
-  --storage-pool NAME      Fuerza pool (por defecto: valor de YAML o 'auto')
-  --disk-size GiB          Sobrescribe tamaño de disco de arranque
-  --dry-run                No ejecuta, solo muestra (en apply/render)
-  --channel NAME           Filtro para 'list'
+  --vmid N                 VMID obligatorio para render/apply (100-999999999)
+  --storage-pool NAME      Fuerza pool (por defecto: valor de YAML o auto)
+  --disk-size GiB          Sobrescribe tamano de disco de arranque
+  --dry-run                No ejecuta, solo muestra (apply/render)
+  --channel NAME           Filtro para list
   --path PATH              Directorio base (por defecto: templates/)
 
 Ejemplos:
-  templatectl.sh list --channel Stable
-  templatectl.sh validate templates/
-  templatectl.sh render templates/windows/windows-gaming.yaml --vmid 200 --storage-pool local-lvm --dry-run
-  sudo templatectl.sh apply templates/linux/linux-workstation.yaml --vmid 210 --storage-pool auto
+  src/tools/templatectl.sh list --channel Stable
+  src/tools/templatectl.sh validate templates/
+  src/tools/templatectl.sh render templates/windows/windows-gaming.yaml --vmid 200 --storage-pool local-lvm
+  sudo src/tools/templatectl.sh apply templates/linux/linux-workstation.yaml --vmid 210 --storage-pool auto
 EOF
 }
 
-yaml_get() {
-  local file="$1" q="$2"
-  yq eval -r "$q" "$file"
+validate_vmid_arg() {
+  local vmid="$1"
+  [[ "$vmid" =~ ^[0-9]+$ ]] || die "--vmid debe ser numerico"
+  (( vmid >= 100 && vmid <= 999999999 )) || die "--vmid debe estar entre 100 y 999999999"
 }
 
-cmd_list() {
-  local channel="" base="templates"
+validate_storage_pool_arg() {
+  local pool="$1"
+  [[ -z "$pool" ]] && return 0
+  [[ "$pool" == "auto" || "$pool" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$ ]] \
+    || die "--storage-pool contiene caracteres no soportados"
+}
+
+validate_disk_size_arg() {
+  local size="$1"
+  [[ -z "$size" ]] && return 0
+  [[ "$size" =~ ^[0-9]+$ ]] || die "--disk-size debe ser numerico"
+  (( size >= 8 && size <= 65536 )) || die "--disk-size debe estar entre 8 y 65536 GiB"
+}
+
+parse_render_apply_args() {
+  local -n out_vmid=$1
+  local -n out_pool=$2
+  local -n out_disk=$3
+  local -n out_dry=$4
+  local -n out_no_template=$5
+  shift 5
+
+  out_vmid=""
+  out_pool=""
+  out_disk=""
+  out_dry="false"
+  out_no_template="false"
+
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --channel) channel="${2:-}"; shift 2;;
-      --path)    base="${2:-}"; shift 2;;
-      -h|--help) usage; exit 0;;
-      *) die "Flag desconocido para list: $1";;
+      --vmid)
+        out_vmid="${2:-}"
+        shift 2
+        ;;
+      --storage-pool)
+        out_pool="${2:-}"
+        shift 2
+        ;;
+      --disk-size)
+        out_disk="${2:-}"
+        shift 2
+        ;;
+      --dry-run)
+        out_dry="true"
+        shift
+        ;;
+      --no-convert-template)
+        out_no_template="true"
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        die "Flag desconocido: $1"
+        ;;
     esac
   done
 
-  require_tools yq jq find
+  [[ -n "$out_vmid" ]] || die "--vmid es obligatorio"
+  validate_vmid_arg "$out_vmid"
+  validate_storage_pool_arg "$out_pool"
+  validate_disk_size_arg "$out_disk"
+}
 
-  [[ -d "$base" ]] || die "No existe el directorio: $base"
-  mapfile -d '' files < <(find "$base" -type f -name '*.yaml' -print0)
+cmd_list() {
+  local channel=""
+  local base="templates"
 
-  printf "%-28s %-12s %-10s %-10s %s\n" "TEMPLATE" "CHANNEL" "VERSION" "OSTYPE" "PATH"
-  printf "%-28s %-12s %-10s %-10s %s\n" "--------" "-------" "-------" "------" "----"
-  for f in "${files[@]}"; do
-    local ch ver name ost
-    ch="$(yaml_get "$f" '.metadata.channel')" || true
-    ver="$(yaml_get "$f" '.metadata.version')" || true
-    name="$(yaml_get "$f" '.metadata.name')" || true
-    ost="$(yaml_get "$f" '.spec.vm.ostype')" || true
-
-    [[ -n "$channel" && "$ch" != "$channel" ]] && continue
-    printf "%-28s %-12s %-10s %-10s %s\n" "$name" "$ch" "$ver" "$ost" "$f"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --channel)
+        channel="${2:-}"
+        shift 2
+        ;;
+      --path)
+        base="${2:-}"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        die "Flag desconocido para list: $1"
+        ;;
+    esac
   done
+
+  require_tools python3
+  [[ -d "$base" ]] || die "No existe el directorio: $base"
+
+  python3 - "$base" "$channel" <<'PY'
+import os
+import sys
+
+try:
+    import yaml
+except Exception as exc:
+    print(f"ERROR: falta Python module PyYAML: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+base, channel = sys.argv[1], sys.argv[2]
+rows = []
+for root, _, files in os.walk(base):
+    for name in sorted(files):
+        if not name.endswith(".yaml"):
+            continue
+        path = os.path.join(root, name)
+        with open(path, "r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+        meta = data.get("metadata", {})
+        spec = data.get("spec", {})
+        vm = spec.get("vm", {})
+        ch = meta.get("channel", "")
+        if channel and ch != channel:
+            continue
+        rows.append((meta.get("name", ""), ch, meta.get("version", ""), vm.get("ostype", ""), path))
+
+print(f"{'TEMPLATE':<28} {'CHANNEL':<12} {'VERSION':<12} {'OSTYPE':<10} PATH")
+print(f"{'--------':<28} {'-------':<12} {'-------':<12} {'------':<10} ----")
+for row in rows:
+    print(f"{row[0]:<28} {row[1]:<12} {row[2]:<12} {row[3]:<10} {row[4]}")
+PY
 }
 
 cmd_validate() {
   local target="${1:-}"
   [[ -n "$target" ]] || die "Uso: validate <path|file>"
-  require_tools python3 yq
-
+  require_tools python3
   [[ -f "$SCHEMA_PATH" ]] || die "No se encuentra el schema: $SCHEMA_PATH"
 
-  python3 - <<PY
-import sys, json, glob, os, yaml
-from jsonschema import Draft202012Validator as V
+  python3 - "$SCHEMA_PATH" "$target" <<'PY'
+import glob
+import json
+import os
+import sys
 
-schema_path = "${SCHEMA_PATH}"
-with open(schema_path, 'r') as f:
-    schema = json.load(f)
-validator = V(schema)
-
-def validate_file(p):
-    with open(p, 'r') as f:
-        data = yaml.safe_load(f)
-    validator.validate(data)
-    print("OK", p)
-
-arg = "${target}"
-if os.path.isdir(arg):
-    for p in glob.glob(os.path.join(arg, '**/*.yaml'), recursive=True):
-        validate_file(p)
-elif os.path.isfile(arg):
-    validate_file(arg)
-else:
-    print(f"Ruta no válida: {arg}", file=sys.stderr)
+try:
+    import yaml
+    from jsonschema import Draft202012Validator
+except Exception as exc:
+    print(f"ERROR: faltan modulos Python requeridos (PyYAML/jsonschema): {exc}", file=sys.stderr)
     sys.exit(1)
+
+schema_path, target = sys.argv[1], sys.argv[2]
+with open(schema_path, "r", encoding="utf-8") as fh:
+    schema = json.load(fh)
+
+validator = Draft202012Validator(schema)
+
+if os.path.isdir(target):
+    files = sorted(glob.glob(os.path.join(target, "**", "*.yaml"), recursive=True))
+elif os.path.isfile(target):
+    files = [target]
+else:
+    print(f"Ruta no valida: {target}", file=sys.stderr)
+    sys.exit(1)
+
+failed = False
+for path in files:
+    with open(path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path))
+    if errors:
+        failed = True
+        print(f"FAIL {path}", file=sys.stderr)
+        for error in errors:
+            where = ".".join(str(p) for p in error.absolute_path) or "<root>"
+            print(f"  - {where}: {error.message}", file=sys.stderr)
+    else:
+        print(f"OK {path}")
+
+sys.exit(1 if failed else 0)
 PY
 }
 
-common_parse_render_apply() {
-  local -n _vmid=$1 _pool=$2 _disk=$3 _dry=$4 _no_tmpl=$5
-  _vmid=""; _pool=""; _disk=""; _dry="false"; _no_tmpl="false"
-  while [[ $# -gt 0 ]]; do
-    case "$6" in
-      --vmid)                _vmid="${7:-}"; shift 2;;
-      --storage-pool)        _pool="${7:-}"; shift 2;;
-      --disk-size)           _disk="${7:-}"; shift 2;;
-      --dry-run)             _dry="true"; shift 1;;
-      --no-convert-template) _no_tmpl="true"; shift 1;;
-      *) break;;
-    esac
-  done
+render_args_array() {
+  local file="$1"
+  local vmid="$2"
+  local pool="$3"
+  local disk="$4"
+  local format="$5"
+
+  local argv=("$RENDERER" --file "$file" --vmid "$vmid" --format "$format")
+  [[ -n "$pool" ]] && argv+=(--storage-pool "$pool")
+  [[ -n "$disk" ]] && argv+=(--disk-size "$disk")
+  "${argv[@]}"
 }
 
 cmd_render() {
-  local file="${1:-}"; shift || true
+  local file="${1:-}"
+  shift || true
   [[ -f "$file" ]] || die "Fichero YAML no encontrado: $file"
-  require_tools yq jq
-
-  local vmid pool disk dry no_tmpl
-  common_parse_render_apply vmid pool disk dry no_tmpl "$@"
-
-  [[ -n "$vmid" ]] || die "--vmid es obligatorio"
   [[ -x "$RENDERER" ]] || die "Renderer no ejecutable: $RENDERER"
 
-  "$RENDERER" \
-    --file "$file" \
-    --vmid "$vmid" \
-    ${pool:+--storage-pool "$pool"} \
-    ${disk:+--disk-size "$disk"} \
-    ${dry:+--dry-run}
+  local vmid pool disk dry no_template
+  parse_render_apply_args vmid pool disk dry no_template "$@"
+
+  render_args_array "$file" "$vmid" "$pool" "$disk" human
 }
 
 cmd_apply() {
-  local file="${1:-}"; shift || true
+  local file="${1:-}"
+  shift || true
   [[ -f "$file" ]] || die "Fichero YAML no encontrado: $file"
-  require_tools yq jq
+  [[ -x "$RENDERER" ]] || die "Renderer no ejecutable: $RENDERER"
 
-  local vmid pool disk dry no_tmpl
-  common_parse_render_apply vmid pool disk dry no_tmpl "$@"
-  [[ -n "$vmid" ]] || die "--vmid es obligatorio"
+  local vmid pool disk dry no_template
+  parse_render_apply_args vmid pool disk dry no_template "$@"
 
-  # En apply, necesitamos 'qm'
-  require_tools qm pvesm
+  local plan_file
+  plan_file="$(mktemp "${TMPDIR:-/tmp}/pecu-template-plan.XXXXXX.json")"
 
-  # Generamos comandos
-  mapfile -t cmds < <("$RENDERER" --file "$file" --vmid "$vmid" ${pool:+--storage-pool "$pool"} ${disk:+--disk-size "$disk"} )
-
-  if [[ "${dry}" == "true" ]]; then
-    printf "%s\n" "${cmds[@]}"
-    echo "# [dry-run] No se ejecutó ningún comando."
-    exit 0
+  if ! render_args_array "$file" "$vmid" "$pool" "$disk" json > "$plan_file"; then
+    rm -f "$plan_file"
+    return 1
   fi
 
-  echo "# Ejecutando ${#cmds[@]} comando(s) qm …"
-  for c in "${cmds[@]}"; do
-    echo "+ $c"
-    eval "$c"
-  done
-
-  if [[ "${no_tmpl}" == "false" ]]; then
-    echo "+ qm template ${vmid}"
-    qm template "${vmid}"
+  if [[ "$dry" != "true" ]]; then
+    require_tools qm
   fi
 
-  echo "# Listo. VMID ${vmid} configurada."
+  local rc=0
+  python3 - "$plan_file" "$dry" "$no_template" "$vmid" <<'PY' || rc=$?
+import json
+import shlex
+import shutil
+import subprocess
+import sys
+
+plan_path, dry, no_template, vmid = sys.argv[1:5]
+with open(plan_path, "r", encoding="utf-8") as fh:
+    plan = json.load(fh)
+
+commands = plan.get("commands", [])
+if no_template != "true":
+    commands.append({"argv": ["qm", "template", vmid], "description": "convert to template"})
+
+def validate_argv(argv):
+    if not isinstance(argv, list) or not argv:
+        raise SystemExit("ERROR: comando JSON sin argv valido")
+    if argv[0] != "qm":
+        raise SystemExit(f"ERROR: comando no permitido: {argv[0]!r}")
+    if any(not isinstance(item, str) or item == "" for item in argv):
+        raise SystemExit("ERROR: argv contiene argumentos invalidos")
+
+if dry == "true":
+    for command in commands:
+        desc = command.get("description")
+        if desc:
+            print(f"# {desc}")
+        validate_argv(command.get("argv"))
+        print(shlex.join(command["argv"]))
+    print("# [dry-run] No se ejecuto ningun comando.")
+    sys.exit(0)
+
+if shutil.which("qm") is None:
+    raise SystemExit("ERROR: falta herramienta: qm")
+
+print(f"# Ejecutando {len(commands)} comando(s) qm")
+for command in commands:
+    argv = command.get("argv")
+    validate_argv(argv)
+    print("+ " + shlex.join(argv), flush=True)
+    subprocess.run(argv, check=True)
+
+print(f"# Listo. VMID {vmid} configurada.")
+PY
+  rm -f "$plan_file"
+  return "$rc"
 }
 
 main() {
-  [[ $# -gt 0 ]] || { usage; exit 1; }
-  local cmd="$1"; shift || true
+  [[ $# -gt 0 ]] || {
+    usage
+    exit 1
+  }
+
+  local cmd="$1"
+  shift || true
+
   case "$cmd" in
-    list)     cmd_list "$@";;
-    validate) cmd_validate "$@";;
-    render)   cmd_render "$@";;
-    apply)    cmd_apply "$@";;
-    -h|--help|help) usage;;
-    *) die "Comando desconocido: $cmd";;
+    list)
+      cmd_list "$@"
+      ;;
+    validate)
+      cmd_validate "$@"
+      ;;
+    render)
+      cmd_render "$@"
+      ;;
+    apply)
+      cmd_apply "$@"
+      ;;
+    -h|--help|help)
+      usage
+      ;;
+    *)
+      die "Comando desconocido: $cmd"
+      ;;
   esac
 }
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -17,31 +17,53 @@ templates/
 
 ## Requisitos
 
-- `bash`, `jq`, `yq` (v4), `python3` con `jsonschema` y `pyyaml`.
-- Host Proxmox (para `apply`), comandos `qm`/`pvesm`.
+- `bash`, `python3` y `PyYAML` para listar/renderizar plantillas.
+- `python3-jsonschema` o el modulo Python `jsonschema` para `validate`.
+- Host Proxmox solo para `apply` real; `apply --dry-run` no requiere `qm`.
 
 ## Uso rápido
 
 ```bash
 # Listar por canal
-src/tools/templatectl.sh list --channel Stable
+src/tools/templatectl.sh list --channel Experimental
 
 # Validar todas
 src/tools/templatectl.sh validate templates/
 
-# Ver comandos (dry-run)
+# Ver comandos humanos seguros. No ejecuta nada.
 src/tools/templatectl.sh render templates/windows/windows-gaming.yaml \
+  --vmid 200 --storage-pool local-lvm
+
+# Aplicar en modo dry-run. Muestra exactamente lo que se ejecutaria.
+src/tools/templatectl.sh apply templates/windows/windows-gaming.yaml \
   --vmid 200 --storage-pool local-lvm --dry-run
 
-# Aplicar (ejecuta qm)
+# Aplicar en un host Proxmox real. Ejecuta qm sin eval ni shell intermedio.
 sudo src/tools/templatectl.sh apply templates/windows/windows-gaming.yaml \
   --vmid 200 --storage-pool local-lvm
 ```
 
 ## Convenciones
 
-* No se fuerza `--machine`; deja que Proxmox seleccione.
-* En `local-lvm` se usan volúmenes LVM-thin (sin `format=`).
-* En `local` (directory) se permite `format=raw`.
-* No se añade ningún dispositivo USB por defecto.
-* Se crean `efidisk0`/`tpmstate0` si están definidos.
+- `apply` ejecuta arrays de argumentos, no strings con `eval`.
+- `spec.vm.chipset: q35` genera `--machine q35` cuando `policy.allowMachinePin: true`.
+- Si `allowMachinePin: false`, el renderer avisa y no aplica `--machine`.
+- En `local-lvm` se usan volúmenes LVM-thin sin `format=`.
+- En `local` (directory) se permite `format=raw` o `format=qcow2`.
+- `--bootdisk` apunta al disco concreto (`scsi0`, `virtio0`, etc.).
+- La red se renderiza como `virtio,bridge=vmbr0,firewall=1`.
+- Se crean `efidisk0` y `tpmstate0` si están definidos.
+- `spec.vm.args` solo se acepta con `policy.allowUnsafeArgs: true`.
+
+## Validación local
+
+```bash
+scripts/validate_repo.sh
+```
+
+El validador local cubre sintaxis Bash, JSON Schema, render dry-run de todas
+las plantillas, `apply --dry-run`, ausencia de `eval` ejecutable y regresiones
+conocidas como `storage.tpm` sin `--tpmstate0` o `--bootdisk scsi`.
+
+`shellcheck` y `yamllint` se ejecutan si están instalados. En CI se instalan
+antes de lanzar el validador.

--- a/templates/linux/linux-workstation.yaml
+++ b/templates/linux/linux-workstation.yaml
@@ -3,8 +3,8 @@ kind: VMTemplate
 metadata:
   name: linux-workstation
   displayName: "Linux Workstation (UEFI, Q35)"
-  version: "2025.08.06"
-  channel: Stable
+  version: "2026.05.11-exp1"
+  channel: Experimental
   compat:
     proxmox: ["8.x"]
 spec:
@@ -35,5 +35,6 @@ spec:
       bridge: vmbr0
       firewall: true
   policy:
-    allowMachinePin: false
+    allowMachinePin: true
     addUsbRootHub: false
+    allowUnsafeArgs: false

--- a/templates/linux/media-server.yaml
+++ b/templates/linux/media-server.yaml
@@ -3,8 +3,8 @@ kind: VMTemplate
 metadata:
   name: media-server
   displayName: "Media Server (UEFI, Q35)"
-  version: "2025.08.06"
-  channel: Stable
+  version: "2026.05.11-exp1"
+  channel: Experimental
   compat:
     proxmox: ["8.x"]
 spec:
@@ -35,5 +35,6 @@ spec:
       bridge: vmbr0
       firewall: true
   policy:
-    allowMachinePin: false
+    allowMachinePin: true
     addUsbRootHub: false
+    allowUnsafeArgs: false

--- a/templates/schemas/template.schema.json
+++ b/templates/schemas/template.schema.json
@@ -10,18 +10,30 @@
       "type": "object",
       "required": ["name", "version", "channel"],
       "properties": {
-        "name": { "type": "string", "pattern": "^[a-z0-9-]+$" },
-        "displayName": { "type": "string" },
-        "version": { "type": "string" },
+        "name": { "$ref": "#/$defs/templateName" },
+        "displayName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 96
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^[0-9]{4}\\.[0-9]{2}\\.[0-9]{2}([.-][A-Za-z0-9]+)?$"
+        },
         "channel": { "enum": ["Stable", "Beta", "Experimental"] },
         "compat": {
           "type": "object",
           "properties": {
             "proxmox": {
               "type": "array",
-              "items": { "type": "string" }
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "pattern": "^[0-9]+\\.x$"
+              }
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -34,16 +46,49 @@
           "type": "object",
           "required": ["ostype", "cpu", "sockets", "cores", "memoryMiB", "chipset", "bios"],
           "properties": {
-            "ostype": { "type": "string" },
-            "name": { "type": "string", "pattern": "^[a-z0-9-]+$" },
-            "cpu": { "type": "string" },
-            "sockets": { "type": "integer", "minimum": 1 },
-            "cores": { "type": "integer", "minimum": 1 },
-            "memoryMiB": { "type": "integer", "minimum": 256 },
+            "ostype": {
+              "enum": [
+                "l24",
+                "l26",
+                "solaris",
+                "other",
+                "win7",
+                "win8",
+                "win10",
+                "win11",
+                "w2k",
+                "w2k3",
+                "w2k8",
+                "wvista",
+                "wxp"
+              ]
+            },
+            "name": { "$ref": "#/$defs/vmName" },
+            "cpu": { "$ref": "#/$defs/cpuString" },
+            "sockets": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 8
+            },
+            "cores": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 512
+            },
+            "memoryMiB": {
+              "type": "integer",
+              "minimum": 256,
+              "maximum": 1048576
+            },
             "chipset": { "enum": ["q35", "i440fx", "auto"] },
             "bios": { "enum": ["ovmf", "seabios"] },
             "tablet": { "type": "boolean" },
-            "args": { "type": "string" }
+            "args": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 512,
+              "pattern": "^[A-Za-z0-9_.,=:+\\-/ ]+$"
+            }
           },
           "additionalProperties": false
         },
@@ -51,13 +96,22 @@
           "type": "object",
           "required": ["pool", "bootdisk"],
           "properties": {
-            "pool": { "enum": ["auto", "local-lvm", "local"] },
+            "pool": {
+              "anyOf": [
+                { "const": "auto" },
+                { "$ref": "#/$defs/storageId" }
+              ]
+            },
             "bootdisk": {
               "type": "object",
               "required": ["bus", "sizeGiB"],
               "properties": {
                 "bus": { "enum": ["scsi", "virtio", "sata", "ide"] },
-                "sizeGiB": { "type": "integer", "minimum": 8 },
+                "sizeGiB": {
+                  "type": "integer",
+                  "minimum": 8,
+                  "maximum": 65536
+                },
                 "format": { "enum": ["raw", "qcow2"] }
               },
               "additionalProperties": false
@@ -66,7 +120,11 @@
               "type": "object",
               "required": ["sizeGiB"],
               "properties": {
-                "sizeGiB": { "type": "integer", "minimum": 1 },
+                "sizeGiB": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 64
+                },
                 "preEnrolledKeys": { "type": "boolean" }
               },
               "additionalProperties": false
@@ -75,7 +133,11 @@
               "type": "object",
               "required": ["sizeGiB", "version"],
               "properties": {
-                "sizeGiB": { "type": "integer", "minimum": 1 },
+                "sizeGiB": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 64
+                },
                 "version": { "enum": ["v2.0"] }
               },
               "additionalProperties": false
@@ -86,12 +148,16 @@
         "network": {
           "type": "array",
           "minItems": 1,
+          "maxItems": 8,
           "items": {
             "type": "object",
             "required": ["model", "bridge"],
             "properties": {
               "model": { "enum": ["virtio", "e1000", "vmxnet3", "rtl8139"] },
-              "bridge": { "type": "string" },
+              "bridge": {
+                "type": "string",
+                "pattern": "^vmbr[0-9]{1,4}$"
+              },
               "firewall": { "type": "boolean" }
             },
             "additionalProperties": false
@@ -99,15 +165,77 @@
         },
         "policy": {
           "type": "object",
-          "required": ["allowMachinePin", "addUsbRootHub"],
+          "required": ["allowMachinePin", "addUsbRootHub", "allowUnsafeArgs"],
           "properties": {
             "allowMachinePin": { "type": "boolean" },
-            "addUsbRootHub": { "type": "boolean" }
+            "addUsbRootHub": { "type": "boolean" },
+            "allowUnsafeArgs": { "type": "boolean" }
           },
           "additionalProperties": false
         }
       },
       "additionalProperties": false
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "spec": {
+            "properties": {
+              "vm": {
+                "required": ["args"],
+                "properties": {
+                  "args": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "spec": {
+            "properties": {
+              "policy": {
+                "required": ["allowUnsafeArgs"],
+                "properties": {
+                  "allowUnsafeArgs": { "const": true }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "templateName": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 63,
+      "pattern": "^[a-z0-9][a-z0-9-]{0,62}$"
+    },
+    "vmName": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 63,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9-]{0,62}$"
+    },
+    "storageId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$"
+    },
+    "cpuString": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9_.+-]+(,[A-Za-z0-9_.+-]+(=[A-Za-z0-9_.:+-]+)?)*$"
     }
   },
   "additionalProperties": false

--- a/templates/windows/windows-gaming.yaml
+++ b/templates/windows/windows-gaming.yaml
@@ -3,8 +3,8 @@ kind: VMTemplate
 metadata:
   name: windows-gaming
   displayName: "Windows Gaming (UEFI, Q35, Win11)"
-  version: "2025.08.06"
-  channel: Stable            # Stable | Beta | Experimental
+  version: "2026.05.11-exp1"
+  channel: Experimental      # Stable | Beta | Experimental
   compat:
     proxmox: ["8.x"]
 spec:
@@ -36,5 +36,6 @@ spec:
       bridge: vmbr0
       firewall: true
   policy:
-    allowMachinePin: false
+    allowMachinePin: true
     addUsbRootHub: false
+    allowUnsafeArgs: true


### PR DESCRIPTION
<!--
PECU-Channel: Experimental
PECU-Title: Template System Hardening and Release Safety Review
PECU-Desc: Safer VM template rendering, stronger validation, CI checks, and release/security documentation cleanup.
-->

# PECU Experimental Release - Template System Hardening

## Why this release exists

This release reduces risk in the PECU template system and aligns release
packaging, validation, and security documentation with the current project
state. It is not a Stable release because the renderer, template validation,
release workflow, and safety checks changed in structural ways.

## Main changes

- Hardened VM template rendering.
- Removed the unsafe eval-based template apply flow.
- Fixed TPM generation from `spec.storage.tpm`.
- Fixed boot disk generation to target `scsi0` instead of the bus name `scsi`.
- Corrected Proxmox network syntax for `qm`.
- Added explicit Q35 machine handling for the Windows 11 template.
- Added stricter JSON Schema validation for template input.
- Added a local repository validation script.
- Added CI coverage for template validation and dry-run rendering.
- Cleaned release packaging so the tarball contains the runnable project tree.
- Cleaned `SECURITY.md` to avoid unsupported signing or audit claims.
- Tightened release selector telemetry behavior and asset handling.

## Template system

`templatectl.sh render` and `templatectl.sh apply --dry-run` do not require a
real Proxmox host. They validate the YAML, render the `qm` plan, and print the
commands that would be used.

Real `apply` still requires a Proxmox node because it runs `qm`. Commands are
executed as argument arrays instead of shell strings. Raw `spec.vm.args` is
restricted and only accepted when `policy.allowUnsafeArgs: true` is set in the
template.

The bundled templates are marked Experimental in this release. They validate
and dry-run cleanly, but the non-dry-run VM creation path still needs testing
against real Proxmox storage and bridge combinations.

## Security notes

- Removed `eval` from the template apply path.
- Reduced command injection risk from YAML by validating VM IDs, VM names,
  bridges, storage IDs, CPU strings, disk sizes, and raw args.
- `SECURITY.md` now documents the guarantees the repository actually provides.
- Release integrity is based on `SHA256SUMS`; no GPG-signed release assets are
  claimed.

## Validation performed

The following checks passed in the maintainer workspace:

```bash
git diff --check
bash -n scripts/pecu_release_selector.sh
bash -n src/proxmox-configurator.sh
bash -n src/tools/templatectl.sh
bash -n src/tools/renderers/qm.sh
CI=true scripts/validate_repo.sh
grep -RIn --exclude-dir=.git '\beval\b' .
src/tools/templatectl.sh render templates/windows/windows-gaming.yaml \
  --vmid 200 \
  --storage-pool local-lvm \
  --dry-run
```

The Windows render output includes:

- `--machine q35`
- `--bios ovmf`
- `--bootdisk scsi0`
- `--efidisk0`
- `--tpmstate0`
- `--net0 virtio,bridge=vmbr0,firewall=1`

## Known limitations

- No real `qm create` was executed on a Proxmox node in this environment.
- ShellCheck is enforced at error severity; warning-level debt in the larger
  interactive scripts remains.
- `src/proxmox-configurator.sh` is still a large interactive Bash script. This
  release fixes targeted safety issues but does not rewrite it.
- The template schema is intentionally conservative and may reject some valid
  Proxmox edge cases until they are reviewed and added deliberately.

## Recommended testing

Run the repository validation locally:

```bash
CI=true scripts/validate_repo.sh
```

Preview the Windows template on the target host:

```bash
sudo src/tools/templatectl.sh apply templates/windows/windows-gaming.yaml \
  --vmid 200 \
  --storage-pool local-lvm \
  --dry-run
```

Only after reviewing the dry-run plan, test a real apply on a non-production
Proxmox node:

```bash
sudo src/tools/templatectl.sh apply templates/windows/windows-gaming.yaml \
  --vmid 200 \
  --storage-pool local-lvm

qm config 200
```

## Upgrade notes

Treat this as an Experimental release. Do not run it directly on production
hosts without reviewing the dry-run output, checking backups, and keeping
console or out-of-band access available.
